### PR TITLE
Static generics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased] - ReleaseDate
 ### Added
 
+- Static methods of generic structs (and traits) can now be mocked without the
+  hack of duplicating the struct's (or trait's) generic parameters.
+  ([#18](https://github.com/asomers/mockall/pull/18))
+
 - Methods with closure arguments can now be mocked.  Technically they always
   could be, but until now it wasn't possible to call the closure argument from
   `withf` or `returning`.  No special tricks are required by the user.

--- a/mockall/src/lib.rs
+++ b/mockall/src/lib.rs
@@ -679,11 +679,11 @@
 //!
 //! Without trait specialization, it probably won't be possible for Mockall
 //! to support all specializing methods.  However, most specializing methods can
-//! be mocked as generic methods with repeated type parameters, just like static
-//! methods of generic structs.
+//! be mocked as generic methods with repeated type parameters.
 //!
 //! ```
 //! # use mockall::*;
+//! // A struct like this
 //! struct Foo<T>(T);
 //! impl<T> Foo<T> {
 //!     fn foo(&self, t: T) where T: Copy {
@@ -691,6 +691,7 @@
 //!         # unimplemented!()
 //!     }
 //! }
+//! // Can be mocked like this
 //! mock! {
 //!     Foo<T: 'static> {
 //!         fn foo<T2: Copy + 'static>(&self, t: T2);
@@ -841,35 +842,19 @@
 //!
 //! ### Generic static methods
 //!
-//! Mocking static methods of generic structs is a little bit tricky.  If the
-//! static method uses any generic parameters, then those generic parameters
-//! must be duplicated as generic parameters of the static method itself.
-//! Here's an example:
+//! Mocking static methods of generic structs or traits, whether or not the
+//! methods themselves are generic, should work seamlessly.
 //!
 //! ```
 //! # use mockall::*;
-//! // A struct like this:
-//! struct Foo<T> {
-//!     // ...
-//!     # _t0: std::marker::PhantomData<T>
-//! }
-//! impl<T> Foo<T> {
-//!     fn new(t: T) -> Self {
-//!         // ...
-//!         # unimplemented!()
-//!     }
-//! }
-//!
-//! // Can be mocked like this:
 //! mock! {
 //!     Foo<T: 'static> {
-//!         fn new<T2: 'static>(t: T2) -> MockFoo<T2>;
+//!         fn new(t: T) -> MockFoo<T>;
 //!     }
 //! }
 //!
-//! // And used like this:
 //! # fn main() {
-//! MockFoo::<u32>::expect_new::<u32>()
+//! MockFoo::<u32>::expect_new()
 //!     .returning(|_| MockFoo::default());
 //! let mock = MockFoo::<u32>::new(42u32);
 //! # }

--- a/mockall/tests/automock_generic_struct_with_static_method.rs
+++ b/mockall/tests/automock_generic_struct_with_static_method.rs
@@ -5,10 +5,9 @@
 
 use mockall::*;
 
-mock! {
-    Foo<T: 'static> {
-        fn foo(t: T);
-    }
+#[automock]
+trait Foo<T: 'static> {
+    fn foo(t: T);
 }
 
 #[test]

--- a/mockall/tests/mock_generic_constructor.rs
+++ b/mockall/tests/mock_generic_constructor.rs
@@ -6,13 +6,13 @@ use mockall::*;
 
 mock! {
     pub Foo<T: Default +'static> {
-        fn build<T2: Default + 'static>() -> MockFoo<T2>;
+        fn build() -> MockFoo<T>;
     }
 }
 
 #[test]
 fn returning_once() {
-    MockFoo::<i16>::expect_build::<i16>()
+    MockFoo::<i16>::expect_build()
         .return_once(MockFoo::<i16>::default);
 
     let _mock: MockFoo<i16> = MockFoo::<i16>::build();

--- a/mockall/tests/mock_generic_constructor_with_where_clause.rs
+++ b/mockall/tests/mock_generic_constructor_with_where_clause.rs
@@ -6,13 +6,13 @@ use mockall::*;
 
 mock! {
     pub Foo<T> where T: Default + 'static {
-        fn build<T2>() -> MockFoo<T2> where T2: Default + 'static;
+        fn build() -> MockFoo<T>;
     }
 }
 
 #[test]
 fn returning_once() {
-    MockFoo::<i16>::expect_build::<i16>()
+    MockFoo::<i16>::expect_build()
         .return_once(MockFoo::<i16>::default);
 
     let _mock: MockFoo<i16> = MockFoo::<i16>::build();

--- a/mockall/tests/mock_generic_struct_with_generic_static_method.rs
+++ b/mockall/tests/mock_generic_struct_with_generic_static_method.rs
@@ -1,0 +1,18 @@
+// vim: ts=80
+//! A generic struct with a generic method on a different parameter
+
+use mockall::*;
+
+mock! {
+    Foo<T: 'static> {
+        fn foo<Q: 'static>(t: T, q: Q);
+    }
+}
+
+#[test]
+fn with() {
+    MockFoo::<u32>::expect_foo::<i16>()
+        .with(predicate::eq(42u32), predicate::eq(99i16))
+        .returning(|_, _| ());
+    MockFoo::foo(42u32, 99i16);
+}

--- a/mockall_derive/src/expectation.rs
+++ b/mockall_derive/src/expectation.rs
@@ -33,8 +33,11 @@ fn common_methods(
         .map(|(i, argname)| {
             let idx = Index::from(i);
             quote!(
-                if let Some(c) = __mockall_pred.#idx.find_case(false, #argname){
-                    panic!("Expectation didn't match arguments:\n{}", c.tree());
+                if let Some(__mockall_c) =
+                    __mockall_pred.#idx.find_case(false, #argname)
+                {
+                    panic!("Expectation didn't match arguments:\n{}",
+                           __mockall_c.tree());
                 }
             )
         })
@@ -155,7 +158,8 @@ fn common_methods(
 
             /// Expect this expectation to be called any number of times
             /// contained with the given range.
-            fn times<R: Into<::mockall::TimesRange>>(&mut self, __mockall_r: R)
+            fn times<MockallR>(&mut self, __mockall_r: MockallR)
+                where MockallR: Into<::mockall::TimesRange>
             {
                 self.times.times(__mockall_r)
             }
@@ -286,8 +290,8 @@ fn expectation_methods(v: &Visibility,
         ///   - `.times(5..=10)`
         ///   - `.times(..=10)`
         /// * The wildcard: `.times(..)`
-        #v fn times<R>(&mut self, __mockall_r: R) -> &mut Self
-            where R: Into<::mockall::TimesRange>
+        #v fn times<MockallR>(&mut self, __mockall_r: MockallR) -> &mut Self
+            where MockallR: Into<::mockall::TimesRange>
         {
             self.common.times(__mockall_r);
             self
@@ -819,8 +823,10 @@ pub(crate) fn expectation(attrs: &TokenStream,
                 }
 
                 /// Return a reference to a constant value from the `Expectation`
-                #vis fn return_const(&mut self, o: #output) -> &mut Self {
-                    self.result = Some(o);
+                #vis fn return_const(&mut self, __mockall_o: #output)
+                    -> &mut Self
+                {
+                    self.result = Some(__mockall_o);
                     self
                 }
 
@@ -931,9 +937,9 @@ pub(crate) fn expectation(attrs: &TokenStream,
                 /// Convenience method that can be used to supply a return value
                 /// for a `Expectation`.  The value will be returned by mutable
                 /// reference.
-                #vis fn return_var(&mut self, o: #output) -> &mut Self
+                #vis fn return_var(&mut self, __mockall_o: #output) -> &mut Self
                 {
-                    self.result = Some(o);
+                    self.result = Some(__mockall_o);
                     self
                 }
 
@@ -1131,9 +1137,9 @@ pub(crate) fn expectation(attrs: &TokenStream,
 
                 /// Just like
                 /// [`Expectation::times`](struct.Expectation.html#method.times)
-                #vis fn times<R>(&mut self, __mockall_r: R)
+                #vis fn times<MockallR>(&mut self, __mockall_r: MockallR)
                     -> &mut Expectation #egenerics_tg
-                    where R: Into<::mockall::TimesRange>
+                    where MockallR: Into<::mockall::TimesRange>
                 {
                     self.guard.0[self.i].times(__mockall_r)
                 }
@@ -1280,9 +1286,9 @@ pub(crate) fn expectation(attrs: &TokenStream,
 
                 /// Just like
                 /// [`Expectation::times`](struct.Expectation.html#method.times)
-                #vis fn times<R>(&mut self, __mockall_r: R)
+                #vis fn times<MockallR>(&mut self, __mockall_r: MockallR)
                     -> &mut Expectation #egenerics_tg
-                    where R: Into<::mockall::TimesRange>
+                    where MockallR: Into<::mockall::TimesRange>
                 {
                     self.guard.store.get_mut(
                             &::mockall::Key::new::<(#argty_tp)>()


### PR DESCRIPTION
Eliminate the hack for static methods of generic structs whereby the method must repeat the struct's generic parameters in the method definition.