### PR TITLE
Specializing methods can now be seamlessly mocked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,6 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased] - ReleaseDate
 ### Added
 
-- Static methods of generic structs (and traits) can now be mocked without the
-  hack of duplicating the struct's (or trait's) generic parameters.
-  ([#18](https://github.com/asomers/mockall/pull/18))
-
 - Methods with closure arguments can now be mocked.  Technically they always
   could be, but until now it wasn't possible to call the closure argument from
   `withf` or `returning`.  No special tricks are required by the user.
@@ -26,6 +22,15 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   ([#14](https://github.com/asomers/mockall/pull/14))
 
 ### Fixed
+
+- Specializing methods of generic structs (and traits) can now be mocked
+  without the hack of duplicating the struct's (or trait's) generic parameters.
+  ([#19](https://github.com/asomers/mockall/pull/19))
+
+- Static methods of generic structs (and traits) can now be mocked without the
+  hack of duplicating the struct's (or trait's) generic parameters.
+  ([#18](https://github.com/asomers/mockall/pull/18))
+
 ### Removed
 
 ## [0.2.1] - 3 August 2019

--- a/mockall/src/lib.rs
+++ b/mockall/src/lib.rs
@@ -671,39 +671,6 @@
 //! # }
 //! ```
 //!
-//! ### Specializing methods
-//!
-//! A specializing method is a (possibly non-generic) method of a generic struct
-//! that places additional bounds on the struct's generic types via a where
-//! clause.
-//!
-//! Without trait specialization, it probably won't be possible for Mockall
-//! to support all specializing methods.  However, most specializing methods can
-//! be mocked as generic methods with repeated type parameters.
-//!
-//! ```
-//! # use mockall::*;
-//! // A struct like this
-//! struct Foo<T>(T);
-//! impl<T> Foo<T> {
-//!     fn foo(&self, t: T) where T: Copy {
-//!         // ...
-//!         # unimplemented!()
-//!     }
-//! }
-//! // Can be mocked like this
-//! mock! {
-//!     Foo<T: 'static> {
-//!         fn foo<T2: Copy + 'static>(&self, t: T2);
-//!     }
-//! }
-//! # fn main() {
-//! let mut mock = MockFoo::<u32>::new();
-//! mock.expect_foo::<u32>().returning(|_| ());
-//! mock.foo(42u32);
-//! # }
-//! ```
-//!
 //! ## Associated types
 //!
 //! Traits with associated types can be mocked too.  Unlike generic traits, the

--- a/mockall/tests/automock_specializing_methods.rs
+++ b/mockall/tests/automock_specializing_methods.rs
@@ -10,10 +10,9 @@ struct G<T: Copy + Default + 'static>(T);
 #[derive(Clone, Copy)]
 struct NonDefault(u32);
 
-mock!{
-    Foo<T> where T: Copy + 'static {
-        fn foo(&self, t: T) -> G<T> where T: Default;
-    }
+#[automock]
+trait Foo<T> where T: Copy + 'static {
+    fn foo(&self, t: T) -> G<T> where T: Default;
 }
 
 #[test]

--- a/mockall_derive/src/lib.rs
+++ b/mockall_derive/src/lib.rs
@@ -625,6 +625,7 @@ fn method_types(sig: &MethodSig, generics: Option<&Generics>)
     };
 
     let is_expectation_generic = !sig.decl.generics.params.is_empty() ||
+        sig.decl.generics.where_clause.is_some() ||
         (is_static && generics.filter(|g| !g.params.is_empty()).is_some());
 
     let expectation_ident = Ident::new("Expectation", span);


### PR DESCRIPTION
Fixes #18