### PR TITLE
Fix deselfify to work with generic structs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- Methods of generics structs and traits that reference `Self` (such as
+  constructors or comparators) can now be mocked without any hacks.
+  ([#20](https://github.com/asomers/mockall/pull/20))
+
 - Specializing methods of generic structs (and traits) can now be mocked
   without the hack of duplicating the struct's (or trait's) generic parameters.
   ([#19](https://github.com/asomers/mockall/pull/19))

--- a/mockall/tests/automock_constructor_in_generic_trait.rs
+++ b/mockall/tests/automock_constructor_in_generic_trait.rs
@@ -1,0 +1,19 @@
+// vim: tw=80
+//! A generic trait with a non-generic constructor method.
+
+use mockall::*;
+
+#[automock]
+trait Foo<T: 'static> {
+    fn new(t: T) -> Self;
+}
+
+#[test]
+fn return_once() {
+    let mock = MockFoo::<u32>::default();
+
+    MockFoo::<u32>::expect_new()
+        .return_once(move |_| mock);
+
+    let _mock = MockFoo::new(5u32);
+}

--- a/mockall_derive/src/expectation.rs
+++ b/mockall_derive/src/expectation.rs
@@ -719,7 +719,7 @@ pub(crate) fn expectation(attrs: &TokenStream,
             let mut rt = ty.clone();
             destrify(&mut rt);
             if let Some(i) = self_ident {
-                crate::deselfify(&mut rt, i);
+                crate::deselfify(&mut rt, i, generics);
             }
             if let Type::Reference(ref tr) = rt.as_ref() {
                 if tr.lifetime.as_ref().map_or(false, |lt| lt.ident == "static")


### PR DESCRIPTION
It's now possible to automock methods of a generic struct or trait that
reference `Self`.

Fixes #17