### PR TITLE
Fix mocking generic methods that use Self

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,9 +26,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed mocking structs and traits with more than one static method.
   ([#22](https://github.com/asomers/mockall/pull/22))
 
-- Methods of generics structs and traits that reference `Self` (such as
+- Methods of generic structs and traits that reference `Self` (such as
   constructors or comparators) can now be mocked without any hacks.
   ([#21](https://github.com/asomers/mockall/pull/21))
+  ([#25](https://github.com/asomers/mockall/pull/25))
 
 - Specializing methods of generic structs (and traits) can now be mocked
   without the hack of duplicating the struct's (or trait's) generic parameters.

--- a/mockall/tests/automock_generic_constructor.rs
+++ b/mockall/tests/automock_generic_constructor.rs
@@ -1,0 +1,17 @@
+// vim: tw=80
+//! A non-generic struct can have a generic constructor method
+
+use mockall::*;
+
+#[automock]
+trait Foo {
+    fn build<T: 'static>(t: T) -> Self;
+}
+
+#[test]
+fn returning_once() {
+    MockFoo::expect_build::<i16>()
+        .return_once(|_| MockFoo::default());
+
+    let _mock: MockFoo = MockFoo::build::<i16>(-1);
+}

--- a/mockall_derive/src/automock.rs
+++ b/mockall_derive/src/automock.rs
@@ -423,7 +423,7 @@ fn mock_function(vis: &Visibility,
         &format!("{}_expectation", ident),
         Span::call_site());
     let mut out = TokenStream::new();
-    Expectation::new(&TokenStream::new(), &inputs, generics,
+    Expectation::new(&TokenStream::new(), &inputs, None, generics,
         &mod_ident, None, &decl.output, &expect_vis).to_tokens(&mut out);
     quote!(
         ::mockall::lazy_static! {

--- a/mockall_derive/src/lib.rs
+++ b/mockall_derive/src/lib.rs
@@ -246,7 +246,6 @@ fn deselfify(literal_type: &mut Type, actual: &Ident, generics: &Generics) {
                 if seg.ident == "Self" {
                     seg.ident = actual.clone();
                     if let PathArguments::None = seg.arguments {
-                        //let (_, tg, _) = generics.split_for_impl();
                         if !generics.params.is_empty() {
                             let args = Punctuated::from_iter(
                                 generics.params.iter().map(|gp| {
@@ -427,8 +426,6 @@ fn gen_mod_ident(struct_: &Ident, trait_: Option<&Ident>)
 /// Combine two Generics structs, producing a new one that has the union of
 /// their parameters.
 fn merge_generics(x: &Generics, y: &Generics) -> Generics {
-    //dbg!(x);
-    //dbg!(y);
     /// Compare only the identifiers of two GenericParams
     fn cmp_gp_idents(x: &GenericParam, y: &GenericParam) -> bool {
         use GenericParam::*;

--- a/mockall_derive/src/mock.rs
+++ b/mockall_derive/src/mock.rs
@@ -389,9 +389,10 @@ fn gen_struct<T>(mock_ident: &syn::Ident,
             quote!(<>).to_tokens(&mut macro_g);
         }
 
-        Expectation::new(&attrs,
-            &meth_types.expectation_inputs, &merged_g, meth_ident,
-            Some(&mock_ident), output, &expect_vis).to_tokens(&mut mod_body);
+        Expectation::new(&attrs, &meth_types.expectation_inputs,
+                         Some(&generics), &meth_types.expectation_generics,
+                         meth_ident, Some(&mock_ident), output,
+                         &expect_vis).to_tokens(&mut mod_body);
 
         if meth_types.is_static {
             let name = syn::Ident::new(


### PR DESCRIPTION
Now it's possible to automock generic constructor methods

Fixes #23