### PR TITLE
Panic more gracefully when a static method's checkpoint fails

### DIFF
--- a/mockall/tests/mock_struct_with_static_method.rs
+++ b/mockall/tests/mock_struct_with_static_method.rs
@@ -11,7 +11,6 @@ mock!{
 
 #[test]
 #[should_panic(expected = "Expectation called fewer than 1 times")]
-#[ignore = "https://github.com/asomers/mockall/issues/7"]
 fn checkpoint() {
     let mut mock = MockFoo::new();
     MockFoo::expect_bar()

--- a/mockall_derive/src/automock.rs
+++ b/mockall_derive/src/automock.rs
@@ -331,8 +331,10 @@ fn mock_foreign(attrs: Attrs, foreign_mod: ItemForeignMod) -> TokenStream {
                 let obj = Ident::new(
                     &format!("{}_expectation", &f.ident),
                     Span::call_site());
-                quote!(#obj.lock().unwrap().checkpoint();)
-                    .to_tokens(&mut cp_body);
+                quote!(
+                    let _timeses = #obj.lock().unwrap().checkpoint()
+                    .collect::<Vec<_>>();
+                ).to_tokens(&mut cp_body);
                 mock_foreign_function(f).to_tokens(&mut body);
             },
             ForeignItem::Static(s) => {
@@ -350,7 +352,7 @@ fn mock_foreign(attrs: Attrs, foreign_mod: ItemForeignMod) -> TokenStream {
         }
     }
 
-    quote!( pub fn checkpoint() { #cp_body }).to_tokens(&mut body);
+    quote!(pub fn checkpoint() { #cp_body }).to_tokens(&mut body);
     quote!(pub mod #modname { #body })
 }
 
@@ -562,8 +564,10 @@ fn mock_module(mod_: ItemMod) -> TokenStream {
                 let obj = Ident::new(
                     &format!("{}_expectation", &f.ident),
                     Span::call_site());
-                quote!(#obj.lock().unwrap().checkpoint();)
-                    .to_tokens(&mut cp_body);
+                quote!(
+                    let _timeses = #obj.lock().unwrap().checkpoint()
+                    .collect::<Vec<_>>();
+                ).to_tokens(&mut cp_body);
                 mock_native_function(&f).to_tokens(&mut body);
             },
             Item::Mod(_) | Item::ForeignMod(_)

--- a/mockall_derive/src/expectation.rs
+++ b/mockall_derive/src/expectation.rs
@@ -180,8 +180,9 @@ impl<'a> Common<'a> {
             impl #ig Expectations #tg #wc {
                 /// Verify that all current expectations are satisfied and clear
                 /// them.
-                #v fn checkpoint(&mut self) {
-                    self.0.drain(..);
+                #v fn checkpoint(&mut self) -> std::vec::Drain<Expectation #tg>
+                {
+                    self.0.drain(..)
                 }
 
                 /// Create a new expectation for this method.
@@ -221,8 +222,11 @@ impl<'a> Common<'a> {
             impl GenericExpectations {
                 /// Verify that all current expectations are satisfied and clear
                 /// them.  This applies to all sets of generic parameters!
-                #v fn checkpoint(&mut self) {
-                    self.store.clear();
+                #v fn checkpoint(&mut self) ->
+                    std::collections::hash_map::Drain<::mockall::Key,
+                               Box<dyn ::mockall::AnyExpectations>>
+                {
+                    self.store.drain()
                 }
 
                 #v fn new() -> Self {

--- a/mockall_derive/src/mock.rs
+++ b/mockall_derive/src/mock.rs
@@ -336,7 +336,10 @@ fn gen_mock_method(mod_ident: Option<&syn::Ident>,
 
     // Finally this method's contribution to the checkpoint method
     if meth_types.is_static {
-        quote!(#attrs { #expect_obj_name.lock().unwrap().checkpoint(); })
+        quote!(#attrs {
+            let _timeses = #expect_obj_name.lock().unwrap().checkpoint()
+                .collect::<Vec<_>>();
+        })
     } else {
         quote!(#attrs { #expect_obj_name.checkpoint(); })
     }.to_tokens(&mut cp_output);


### PR DESCRIPTION
Previously, a failed checkpoint would trigger a panic with a Mutex held,
poisoning that Mutex and possibly causing future tests to fail.  Now,
the panic will be deferred until after the Mutex gets released,
preventing any poison.

Fixes #7