### PR TITLE
Fix deselfify for trait objects with associated types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- Fixed mocking methods with arguments or return values that use `Self` as an
+  associated type of some other trait.
+  ([#28](https://github.com/asomers/mockall/pull/28))
+
 - Fixed mocking structs and traits with more than one static method.
   ([#22](https://github.com/asomers/mockall/pull/22))
 

--- a/mockall/tests/automock_associated_type_constructor.rs
+++ b/mockall/tests/automock_associated_type_constructor.rs
@@ -1,0 +1,38 @@
+// vim: tw=80
+/// A constructor that returns Self as an associated type of some other trait.
+/// This is very useful when working with Futures.
+
+use mockall::*;
+
+pub trait Future {
+    type Item;
+    type Error;
+}
+
+#[allow(unused)]
+pub struct Foo{}
+
+#[automock]
+impl Foo {
+    pub fn open() -> impl Future<Item=Self, Error=i32> {
+        struct Bar {}
+        impl Future for Bar {
+            type Item=Foo;
+            type Error=i32;
+        }
+        Bar{}
+    }
+}
+
+#[test]
+fn returning() {
+    MockFoo::expect_open().returning(|| {
+        struct Baz {}
+        impl Future for Baz {
+            type Item=MockFoo;
+            type Error=i32;
+        }
+        Box::new(Baz{})
+    });
+    let _a = MockFoo::open();
+}


### PR DESCRIPTION
This is especially important for constructors that return impl
Future<Type=Self,...>