### PR TITLE
Reexport more stuff from the main crate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+- It is no longer necessary for consuming crates to explicitly depend on
+  fragile, downcast, or predicates-tree.  Mockall now reexports them.
+  ([#29](https://github.com/asomers/mockall/pull/29))
+
 - The MSRV is now Rust 1.35.0
   ([#15](https://github.com/asomers/mockall/pull/15))
 

--- a/README.md
+++ b/README.md
@@ -29,10 +29,7 @@ your `Cargo.toml`:
 
 ```toml
 [dev-dependencies]
-downcast = "0.10"
-fragile = "0.3"
 mockall = "0.2"
-predicates-tree = "1.0"
 ```
 
 Then use it like this:

--- a/mockall/src/lib.rs
+++ b/mockall/src/lib.rs
@@ -970,6 +970,11 @@ use std::{
     thread
 };
 
+#[doc(hidden)]
+pub use downcast::{Any, Downcast};
+#[doc(hidden)]
+pub use fragile::Fragile;
+
 /// For mocking static methods
 #[doc(hidden)]
 pub use lazy_static::lazy_static;
@@ -978,6 +983,8 @@ pub use predicates::{
     boolean::PredicateBooleanExt,
     prelude::{Predicate, predicate}
 };
+#[doc(hidden)]
+pub use predicates_tree::CaseTreeExt;
 
 ::cfg_if::cfg_if! {
     if #[cfg(any(not(feature = "nightly"), not(rustdoc)))] {

--- a/mockall_derive/Cargo.toml
+++ b/mockall_derive/Cargo.toml
@@ -31,7 +31,4 @@ quote = "0.6"
 syn = { version = "0.15", features = ["extra-traits", "full"] }
 
 [dev-dependencies]
-downcast = "0.10"
-fragile = "0.3"
-predicates-tree = "1.0"
 pretty_assertions = "0.5"

--- a/mockall_derive/src/expectation.rs
+++ b/mockall_derive/src/expectation.rs
@@ -471,7 +471,7 @@ impl<'a> Expectation<'a> {
             pub mod #ident {
                 #extra_uses
                 use super::*;   // Import types from the calling environment
-                use ::predicates_tree::CaseTreeExt;
+                use ::mockall::CaseTreeExt;
                 use ::std::{
                     mem,
                     ops::{DerefMut, Range},
@@ -701,7 +701,7 @@ impl<'a> StaticExpectation<'a> {
                                                   MockallF) -> &mut Self
                     where MockallF: FnOnce(#(#argty, )*) -> #output + 'static
                 {
-                    let __mockall_fragile = ::fragile::Fragile::new(__mockall_f);
+                    let __mockall_fragile = ::mockall::Fragile::new(__mockall_f);
                     let __mockall_fonce = Box::new(move |#(#argnames: #argty, )*| {
                         (__mockall_fragile.into_inner())(#(#argnames, )*)
                     });
@@ -734,7 +734,7 @@ impl<'a> StaticExpectation<'a> {
                 #v fn returning_st<MockallF>(&mut self, __mockall_f: MockallF) -> &mut Self
                     where MockallF: FnMut(#(#argty, )*) -> #output + 'static
                 {
-                    let mut __mockall_fragile = ::fragile::Fragile::new(__mockall_f);
+                    let mut __mockall_fragile = ::mockall::Fragile::new(__mockall_f);
                     let __mockall_fmut = move |#(#argnames: #argty, )*| {
                         (__mockall_fragile.get_mut())(#(#argnames, )*)
                     };
@@ -1408,7 +1408,7 @@ impl<'a> RefMutExpectation<'a> {
                 #v fn returning_st<MockallF>(&mut self, __mockall_f: MockallF) -> &mut Self
                     where MockallF: FnMut(#(#argty, )*) -> #output + 'static
                 {
-                    let mut __mockall_fragile = ::fragile::Fragile::new(__mockall_f);
+                    let mut __mockall_fragile = ::mockall::Fragile::new(__mockall_f);
                     let __mockall_fmut = move |#(#argnames, )*| {
                         (__mockall_fragile.get_mut())(#(#argnames, )*)
                     };

--- a/mockall_examples/Cargo.toml
+++ b/mockall_examples/Cargo.toml
@@ -20,7 +20,4 @@ features = ["nightly-docs"]
 nightly-docs = []
 
 [dependencies]
-downcast = "0.10"
-fragile = "0.3"
 mockall = { version = "0.2.0", path = "../mockall" }
-predicates-tree = "1.0"


### PR DESCRIPTION
It will no longer be necessary for users to explicitly depend on
Fragile, downcast, and predicates-tree.