### PR TITLE
Better panic messages for failed call counts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased] - ReleaseDate
 ### Added
 ### Changed
+
+- Better panic messages when an expectation fails its expected call count.
+  ([#33](https://github.com/asomers/mockall/pull/33))
+
 ### Fixed
 
 - Methods returning non-`'static` references (mutable or otherwise) will now

--- a/mockall/tests/mock_reference_arguments.rs
+++ b/mockall/tests/mock_reference_arguments.rs
@@ -61,7 +61,8 @@ mod times {
     }
 
     #[test]
-    #[should_panic(expected = "Expectation called fewer than 2 times")]
+    #[should_panic(expected =
+                   "MockFoo::foo: Expectation called fewer than 2 times")]
     fn too_few() {
         let mut mock = MockFoo::new();
         mock.expect_foo()
@@ -71,7 +72,8 @@ mod times {
     }
 
     #[test]
-    #[should_panic(expected = "Expectation called more than 2 times")]
+    #[should_panic(expected =
+                   "MockFoo::foo: Expectation called more than 2 times")]
     fn too_many() {
         let mut mock = MockFoo::new();
         mock.expect_foo()
@@ -95,7 +97,8 @@ mod times {
     }
 
     #[test]
-    #[should_panic(expected = "Expectation called fewer than 2 times")]
+    #[should_panic(expected =
+                   "MockFoo::foo: Expectation called fewer than 2 times")]
     fn range_too_few() {
         let mut mock = MockFoo::new();
         mock.expect_foo()
@@ -105,7 +108,8 @@ mod times {
     }
 
     #[test]
-    #[should_panic(expected = "Expectation called more than 3 times")]
+    #[should_panic(expected =
+                   "MockFoo::foo: Expectation called more than 3 times")]
     fn range_too_many() {
         let mut mock = MockFoo::new();
         mock.expect_foo()

--- a/mockall/tests/mock_return_reference.rs
+++ b/mockall/tests/mock_return_reference.rs
@@ -14,7 +14,8 @@ mod never {
     use super::*;
 
     #[test]
-    #[should_panic(expected = "Expectation should not have been called")]
+    #[should_panic(expected =
+                   "MockFoo::bar: Expectation should not have been called")]
     fn fail() {
         let mut mock = MockFoo::new();
         mock.expect_bar()

--- a/mockall/tests/mock_struct.rs
+++ b/mockall/tests/mock_struct.rs
@@ -40,7 +40,8 @@ mod checkpoint {
     }
 
     #[test]
-    #[should_panic(expected = "Expectation called fewer than 1 times")]
+    #[should_panic(expected =
+                   "MockFoo::foo: Expectation called fewer than 1 times")]
     fn not_yet_satisfied() {
         let mut mock = MockFoo::new();
         mock.expect_foo()
@@ -159,7 +160,8 @@ mod never {
     use super::*;
 
     #[test]
-    #[should_panic(expected = "Expectation should not have been called")]
+    #[should_panic(expected =
+                   "MockFoo::bar: Expectation should not have been called")]
     fn fail() {
         let mut mock = MockFoo::new();
         mock.expect_bar()
@@ -294,7 +296,8 @@ mod times {
     }
 
     #[test]
-    #[should_panic(expected = "Expectation called fewer than 2 times")]
+    #[should_panic(expected =
+                   "MockFoo::baz: Expectation called fewer than 2 times")]
     fn too_few() {
         let mut mock = MockFoo::new();
         mock.expect_baz()
@@ -304,7 +307,8 @@ mod times {
     }
 
     #[test]
-    #[should_panic(expected = "Expectation called more than 2 times")]
+    #[should_panic(expected =
+                   "MockFoo::baz: Expectation called more than 2 times")]
     fn too_many() {
         let mut mock = MockFoo::new();
         mock.expect_baz()
@@ -335,7 +339,8 @@ mod times {
     }
 
     #[test]
-    #[should_panic(expected = "Expectation called fewer than 2 times")]
+    #[should_panic(expected =
+                   "MockFoo::baz: Expectation called fewer than 2 times")]
     fn range_too_few() {
         let mut mock = MockFoo::new();
         mock.expect_baz()
@@ -345,7 +350,8 @@ mod times {
     }
 
     #[test]
-    #[should_panic(expected = "Expectation called more than 3 times")]
+    #[should_panic(expected =
+                   "MockFoo::baz: Expectation called more than 3 times")]
     fn range_too_many() {
         let mut mock = MockFoo::new();
         mock.expect_baz()
@@ -371,7 +377,8 @@ mod times {
     }
 
     #[test]
-    #[should_panic(expected = "Expectation called more than 3 times")]
+    #[should_panic(expected =
+                   "MockFoo::baz: Expectation called more than 3 times")]
     fn rangeto_too_many() {
         let mut mock = MockFoo::new();
         mock.expect_baz()
@@ -413,7 +420,8 @@ mod times {
     }
 
     #[test]
-    #[should_panic(expected = "Expectation called fewer than 2 times")]
+    #[should_panic(expected =
+                   "MockFoo::baz: Expectation called fewer than 2 times")]
     fn rangefrom_too_few() {
         let mut mock = MockFoo::new();
         mock.expect_baz()

--- a/mockall/tests/mock_struct_with_static_method.rs
+++ b/mockall/tests/mock_struct_with_static_method.rs
@@ -10,7 +10,8 @@ mock!{
 }
 
 #[test]
-#[should_panic(expected = "Expectation called fewer than 1 times")]
+#[should_panic(expected =
+    "MockFoo::bar: Expectation called fewer than 1 times")]
 fn checkpoint() {
     let mut mock = MockFoo::new();
     MockFoo::expect_bar()

--- a/mockall_derive/src/automock.rs
+++ b/mockall_derive/src/automock.rs
@@ -426,7 +426,8 @@ fn mock_function(vis: &Visibility,
         Span::call_site());
     let mut out = TokenStream::new();
     Expectation::new(&TokenStream::new(), &inputs, None, generics,
-        &mod_ident, None, &decl.output, &expect_vis).to_tokens(&mut out);
+        &ident, &mod_ident, None, &decl.output, &expect_vis)
+        .to_tokens(&mut out);
     quote!(
         ::mockall::lazy_static! {
             static ref #obj: ::std::sync::Mutex<#expect_obj> = 

--- a/mockall_derive/src/mock.rs
+++ b/mockall_derive/src/mock.rs
@@ -394,7 +394,7 @@ fn gen_struct<T>(mock_ident: &syn::Ident,
 
         Expectation::new(&attrs, &meth_types.expectation_inputs,
                          Some(&generics), &meth_types.expectation_generics,
-                         meth_ident, Some(&mock_ident), output,
+                         meth_ident, meth_ident, Some(&mock_ident), output,
                          &expect_vis).to_tokens(&mut mod_body);
 
         if meth_types.is_static {


### PR DESCRIPTION
The panic messages for a failed call counts panic will now include the
name of the method.

Fixes #31