### PR TITLE
Mock context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Methods with closure arguments and where clauses can now be mocked.
   ([#35](https://github.com/asomers/mockall/pull/35))
 
+- Mocked static methods and free functions now use a Context object to manage
+  their expectations.  The context object will validate call counts when it
+  drops, and clean up any leftover expectations.  This makes it practical to
+  use mocked free functions from multiple test cases.  The user still will most
+  likely need to provide his own synchronization to prevent such test cases
+  from running concurrently.
+  ([#34](https://github.com/asomers/mockall/pull/34))
+
 ### Changed
 
 - Better panic messages when an expectation fails its expected call count.

--- a/mockall/src/lib.rs
+++ b/mockall/src/lib.rs
@@ -818,7 +818,7 @@
 //! # fn main() {
 //! let ctx = MockFoo::<u32>::new_context();
 //! ctx.expect()
-//!     .returning(|_: u32| MockFoo::default());
+//!     .returning(|_| MockFoo::default());
 //! let mock = MockFoo::<u32>::new(42u32);
 //! # }
 //! ```

--- a/mockall/tests/automock_associated_type_constructor.rs
+++ b/mockall/tests/automock_associated_type_constructor.rs
@@ -26,7 +26,8 @@ impl Foo {
 
 #[test]
 fn returning() {
-    MockFoo::expect_open().returning(|| {
+    let ctx = MockFoo::open_context();
+    ctx.expect().returning(|| {
         struct Baz {}
         impl Future for Baz {
             type Item=MockFoo;

--- a/mockall/tests/automock_boxed_constructor.rs
+++ b/mockall/tests/automock_boxed_constructor.rs
@@ -10,6 +10,7 @@ pub trait A {
 
 #[test]
 fn returning() {
-    MockA::expect_new().returning(|| Box::new(MockA::default()));
+    let ctx = MockA::new_context();
+    ctx.expect().returning(|| Box::new(MockA::default()));
     let _a: Box<MockA> = <MockA as A>::new();
 }

--- a/mockall/tests/automock_constructor_impl_trait.rs
+++ b/mockall/tests/automock_constructor_impl_trait.rs
@@ -22,7 +22,8 @@ impl A {
 
 #[test]
 fn returning() {
-    MockA::expect_build().returning(|| {
+    let ctx = MockA::build_context();
+    ctx.expect().returning(|| {
         struct Baz {}
         impl Foo for Baz {}
         Box::new(Baz{})

--- a/mockall/tests/automock_constructor_in_generic_trait.rs
+++ b/mockall/tests/automock_constructor_in_generic_trait.rs
@@ -12,7 +12,8 @@ trait Foo<T: 'static> {
 fn return_once() {
     let mock = MockFoo::<u32>::default();
 
-    MockFoo::<u32>::expect_new()
+    let ctx = MockFoo::<u32>::new_context();
+    ctx.expect()
         .return_once(move |_| mock);
 
     let _mock = MockFoo::new(5u32);

--- a/mockall/tests/automock_constructor_in_struct.rs
+++ b/mockall/tests/automock_constructor_in_struct.rs
@@ -16,6 +16,7 @@ impl A {
 
 #[test]
 fn returning() {
-    MockA::expect_new().returning(MockA::default);
+    let ctx = MockA::new_context();
+    ctx.expect().returning(MockA::default);
     let _a: MockA = MockA::new();
 }

--- a/mockall/tests/automock_constructor_in_trait.rs
+++ b/mockall/tests/automock_constructor_in_trait.rs
@@ -10,6 +10,7 @@ pub trait A {
 
 #[test]
 fn returning() {
-    MockA::expect_new().returning(MockA::default);
+    let ctx = MockA::new_context();
+    ctx.expect().returning(MockA::default);
     let _a: MockA = <MockA as A>::new();
 }

--- a/mockall/tests/automock_constructor_in_trait_with_args.rs
+++ b/mockall/tests/automock_constructor_in_trait_with_args.rs
@@ -13,8 +13,9 @@ trait Foo {
 #[test]
 fn return_once() {
     let mock = MockFoo::default();
+    let ctx = MockFoo::new_context();
 
-    MockFoo::expect_new()
+    ctx.expect()
         .return_once(|_| mock);
 
     let _mock = MockFoo::new(5);

--- a/mockall/tests/automock_constructor_with_args.rs
+++ b/mockall/tests/automock_constructor_with_args.rs
@@ -16,8 +16,9 @@ impl Foo {
 #[test]
 fn return_once() {
     let mock = MockFoo::default();
+    let ctx = MockFoo::new_context();
 
-    MockFoo::expect_new()
+    ctx.expect()
         .return_once(|_| mock);
 
     let _mock = MockFoo::new(5);

--- a/mockall/tests/automock_foreign_c.rs
+++ b/mockall/tests/automock_foreign_c.rs
@@ -10,6 +10,7 @@ extern "C" {
 
 #[test]
 fn returning() {
-    mock_ffi::expect_foo().returning(i64::from);
+    let ctx = mock_ffi::foo_context();
+    ctx.expect().returning(i64::from);
     assert_eq!(42, unsafe{mock_ffi::foo(42)});
 }

--- a/mockall/tests/automock_foreign_c_returning_unit.rs
+++ b/mockall/tests/automock_foreign_c_returning_unit.rs
@@ -12,6 +12,7 @@ extern "C" {
 
 #[test]
 fn returning() {
-    mock_ffi::expect_foo().returning(|| ());
+    let ctx = mock_ffi::foo_context();
+    ctx.expect().returning(|| ());
     unsafe{mock_ffi::foo()};
 }

--- a/mockall/tests/automock_foreign_rust.rs
+++ b/mockall/tests/automock_foreign_rust.rs
@@ -10,6 +10,7 @@ extern "Rust" {
 
 #[test]
 fn returning() {
-    mock_ffi::expect_foo().returning(i64::from);
+    let ctx = mock_ffi::foo_context();
+    ctx.expect().returning(i64::from);
     assert_eq!(42, unsafe{mock_ffi::foo(42)});
 }

--- a/mockall/tests/automock_generic_constructor.rs
+++ b/mockall/tests/automock_generic_constructor.rs
@@ -10,7 +10,8 @@ trait Foo {
 
 #[test]
 fn returning_once() {
-    MockFoo::expect_build::<i16>()
+    let ctx = MockFoo::build_context();
+    ctx.expect::<i16>()
         .return_once(|_| MockFoo::default());
 
     let _mock: MockFoo = MockFoo::build::<i16>(-1);

--- a/mockall/tests/automock_generic_static_method.rs
+++ b/mockall/tests/automock_generic_static_method.rs
@@ -10,7 +10,8 @@ trait A {
 
 #[test]
 fn returning() {
-    MockA::expect_bar::<i16>()
+    let ctx = MockA::bar_context();
+    ctx.expect::<i16>()
         .returning(|_| 42);
     assert_eq!(42, MockA::bar(-1i16));
 }

--- a/mockall/tests/automock_generic_struct_with_static_method.rs
+++ b/mockall/tests/automock_generic_struct_with_static_method.rs
@@ -14,6 +14,6 @@ trait Foo<T: 'static> {
 fn returning() {
     let ctx = MockFoo::<u32>::foo_context();
     ctx.expect()
-        .returning(|_: u32| ());
+        .returning(|_| ());
     MockFoo::foo(42u32);
 }

--- a/mockall/tests/automock_generic_struct_with_static_method.rs
+++ b/mockall/tests/automock_generic_struct_with_static_method.rs
@@ -12,7 +12,8 @@ trait Foo<T: 'static> {
 
 #[test]
 fn returning() {
-    MockFoo::<u32>::expect_foo()
-        .returning(|_| ());
+    let ctx = MockFoo::<u32>::foo_context();
+    ctx.expect()
+        .returning(|_: u32| ());
     MockFoo::foo(42u32);
 }

--- a/mockall/tests/automock_many_args.rs
+++ b/mockall/tests/automock_many_args.rs
@@ -47,7 +47,8 @@ fn return_var() {
 
 #[test]
 fn static_method_returning() {
-    MockManyArgs::expect_bean()
+    let ctx = MockManyArgs::bean_context();
+    ctx.expect()
         .returning(|_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _|  ());
     MockManyArgs::bean(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
 }

--- a/mockall/tests/automock_module.rs
+++ b/mockall/tests/automock_module.rs
@@ -20,7 +20,8 @@ cfg_if! {
 
             #[test]
             fn returning() {
-                mock_foo::expect_bar()
+                let ctx = mock_foo::bar_context();
+                ctx.expect()
                     .returning(|x| i64::from(x) + 1);
                 assert_eq!(5, mock_foo::bar(4));
             }

--- a/mockall/tests/automock_static_method.rs
+++ b/mockall/tests/automock_static_method.rs
@@ -10,7 +10,8 @@ trait A {
 
 #[test]
 fn returning() {
-    MockA::expect_bar()
+    let ctx = MockA::bar_context();
+    ctx.expect()
         .returning(|| 42);
     assert_eq!(42, MockA::bar());
 }

--- a/mockall/tests/mock_closure.rs
+++ b/mockall/tests/mock_closure.rs
@@ -58,7 +58,8 @@ mod returning {
 
     #[test]
     fn static_method() {
-        MockFoo::expect_bean()
+        let ctx = MockFoo::bean_context();
+        ctx.expect()
             .returning(|f| f(42));
         assert_eq!(84, MockFoo::bean(|x| 2 * x));
     }

--- a/mockall/tests/mock_constructor_with_args.rs
+++ b/mockall/tests/mock_constructor_with_args.rs
@@ -16,7 +16,8 @@ mock! {
 fn returning_once() {
     let mock = MockFoo::default();
 
-    MockFoo::expect_new()
+    let ctx = MockFoo::new_context();
+    ctx.expect()
         .return_once(|_| mock);
 
     let _mock = MockFoo::new(5);

--- a/mockall/tests/mock_generic_constructor.rs
+++ b/mockall/tests/mock_generic_constructor.rs
@@ -12,7 +12,8 @@ mock! {
 
 #[test]
 fn returning_once() {
-    MockFoo::<i16>::expect_build()
+    let ctx = MockFoo::<i16>::build_context();
+    ctx.expect()
         .return_once(MockFoo::<i16>::default);
 
     let _mock: MockFoo<i16> = MockFoo::<i16>::build();

--- a/mockall/tests/mock_generic_constructor_with_where_clause.rs
+++ b/mockall/tests/mock_generic_constructor_with_where_clause.rs
@@ -12,7 +12,8 @@ mock! {
 
 #[test]
 fn returning_once() {
-    MockFoo::<i16>::expect_build()
+    let ctx = MockFoo::<i16>::build_context();
+    ctx.expect()
         .return_once(MockFoo::<i16>::default);
 
     let _mock: MockFoo<i16> = MockFoo::<i16>::build();

--- a/mockall/tests/mock_generic_static_method_with_where_clause.rs
+++ b/mockall/tests/mock_generic_static_method_with_where_clause.rs
@@ -16,7 +16,8 @@ mock! {
 
 #[test]
 fn returning() {
-    MockFoo::expect_make_g::<i16>()
+    let ctx = MockFoo::make_g_context();
+    ctx.expect::<i16>()
         .returning(|t| G{t});
     let g = MockFoo::make_g(42i16);
     assert_eq!(g.t, 42i16);

--- a/mockall/tests/mock_generic_struct_with_generic_static_method.rs
+++ b/mockall/tests/mock_generic_struct_with_generic_static_method.rs
@@ -23,8 +23,8 @@ fn checkpoint() {
 
     let mut mock = MockFoo::<u32>::new();
     let ctx = MockFoo::<u32>::foo_context();
-    ctx.expect()
-        .returning(|_: u32, _: i16| 0)
+    ctx.expect::<i16>()
+        .returning(|_, _| 0)
         .times(1..3);
     mock.checkpoint();
     panic!("Shouldn't get here!");
@@ -38,8 +38,8 @@ fn ctx_checkpoint() {
     let _m = BAR_MTX.lock();
 
     let ctx = MockFoo::<u32>::foo_context();
-    ctx.expect()
-        .returning(|_: u32, _: i16| 0)
+    ctx.expect::<i16>()
+        .returning(|_, _| 0)
         .times(1..3);
     ctx.checkpoint();
     panic!("Shouldn't get here!");
@@ -53,8 +53,8 @@ fn ctx_hygiene() {
 
     {
         let ctx0 = MockFoo::<u32>::foo_context();
-        ctx0.expect()
-            .returning(|_: u32, _: i16| 0);
+        ctx0.expect::<i16>()
+            .returning(|_, _| 0);
     }
     MockFoo::foo(42, 69);
 }
@@ -65,7 +65,7 @@ fn return_default() {
     let _m = BAR_MTX.lock();
 
     let ctx = MockFoo::<u32>::foo_context();
-    ctx.expect::<u32, i16>();
+    ctx.expect::<i16>();
     MockFoo::foo(5u32, 6i16);
 }
 
@@ -74,8 +74,8 @@ fn returning() {
     let _m = BAR_MTX.lock();
 
     let ctx = MockFoo::<u32>::foo_context();
-    ctx.expect()
-        .returning(|_: u32, _: i16| 0);
+    ctx.expect::<i16>()
+        .returning(|_, _| 0);
     MockFoo::foo(41u32, 42i16);
 }
 
@@ -84,10 +84,10 @@ fn two_matches() {
     let _m = BAR_MTX.lock();
 
     let ctx = MockFoo::<u32>::foo_context();
-    ctx.expect()
+    ctx.expect::<i16>()
         .with(predicate::eq(42u32), predicate::eq(0i16))
         .return_const(99u64);
-    ctx.expect()
+    ctx.expect::<i16>()
         .with(predicate::eq(69u32), predicate::eq(0i16))
         .return_const(101u64);
     assert_eq!(101, MockFoo::foo(69u32, 0i16));
@@ -99,8 +99,8 @@ fn with() {
     let _m = BAR_MTX.lock();
 
     let ctx = MockFoo::<u32>::foo_context();
-    ctx.expect()
+    ctx.expect::<i16>()
         .with(predicate::eq(42u32), predicate::eq(99i16))
-        .returning(|_: u32, _: i16| 0);
+        .returning(|_, _| 0);
     MockFoo::foo(42u32, 99i16);
 }

--- a/mockall/tests/mock_generic_struct_with_generic_static_method.rs
+++ b/mockall/tests/mock_generic_struct_with_generic_static_method.rs
@@ -2,17 +2,105 @@
 //! A generic struct with a generic method on a different parameter
 
 use mockall::*;
+use std::sync::Mutex;
 
 mock! {
     Foo<T: 'static> {
-        fn foo<Q: 'static>(t: T, q: Q);
+        fn foo<Q: 'static>(t: T, q: Q) -> u64;
     }
+}
+
+lazy_static! {
+    static ref BAR_MTX: Mutex<()> = Mutex::new(());
+}
+
+// Checkpointing the mock object should check static methods
+#[test]
+#[should_panic(expected =
+    "MockFoo::foo: Expectation called fewer than 1 times")]
+fn checkpoint() {
+    let _m = BAR_MTX.lock();
+
+    let mut mock = MockFoo::<u32>::new();
+    let ctx = MockFoo::<u32>::foo_context();
+    ctx.expect()
+        .returning(|_: u32, _: i16| 0)
+        .times(1..3);
+    mock.checkpoint();
+    panic!("Shouldn't get here!");
+}
+
+// It should also be possible to checkpoint just the context object
+#[test]
+#[should_panic(expected =
+    "MockFoo::foo: Expectation called fewer than 1 times")]
+fn ctx_checkpoint() {
+    let _m = BAR_MTX.lock();
+
+    let ctx = MockFoo::<u32>::foo_context();
+    ctx.expect()
+        .returning(|_: u32, _: i16| 0)
+        .times(1..3);
+    ctx.checkpoint();
+    panic!("Shouldn't get here!");
+}
+
+// Expectations should be cleared when a context object drops
+#[test]
+#[should_panic(expected = "No matching expectation found")]
+fn ctx_hygiene() {
+    let _m = BAR_MTX.lock();
+
+    {
+        let ctx0 = MockFoo::<u32>::foo_context();
+        ctx0.expect()
+            .returning(|_: u32, _: i16| 0);
+    }
+    MockFoo::foo(42, 69);
+}
+
+#[cfg_attr(not(feature = "nightly"), ignore)]
+#[test]
+fn return_default() {
+    let _m = BAR_MTX.lock();
+
+    let ctx = MockFoo::<u32>::foo_context();
+    ctx.expect::<u32, i16>();
+    MockFoo::foo(5u32, 6i16);
+}
+
+#[test]
+fn returning() {
+    let _m = BAR_MTX.lock();
+
+    let ctx = MockFoo::<u32>::foo_context();
+    ctx.expect()
+        .returning(|_: u32, _: i16| 0);
+    MockFoo::foo(41u32, 42i16);
+}
+
+#[test]
+fn two_matches() {
+    let _m = BAR_MTX.lock();
+
+    let ctx = MockFoo::<u32>::foo_context();
+    ctx.expect()
+        .with(predicate::eq(42u32), predicate::eq(0i16))
+        .return_const(99u64);
+    ctx.expect()
+        .with(predicate::eq(69u32), predicate::eq(0i16))
+        .return_const(101u64);
+    assert_eq!(101, MockFoo::foo(69u32, 0i16));
+    assert_eq!(99, MockFoo::foo(42u32, 0i16));
 }
 
 #[test]
 fn with() {
-    MockFoo::<u32>::expect_foo::<i16>()
+    let _m = BAR_MTX.lock();
+
+    let ctx = MockFoo::<u32>::foo_context();
+    ctx.expect()
         .with(predicate::eq(42u32), predicate::eq(99i16))
-        .returning(|_, _| ());
+        .returning(|_: u32, _: i16| 0);
     MockFoo::foo(42u32, 99i16);
 }

--- a/mockall/tests/mock_generic_struct_with_static_method.rs
+++ b/mockall/tests/mock_generic_struct_with_static_method.rs
@@ -15,6 +15,6 @@ mock! {
 fn returning() {
     let ctx = MockFoo::<u32>::foo_context();
     ctx.expect()
-        .returning(|_: u32| ());
+        .returning(|_| ());
     MockFoo::foo(42u32);
 }

--- a/mockall/tests/mock_generic_struct_with_static_method.rs
+++ b/mockall/tests/mock_generic_struct_with_static_method.rs
@@ -13,7 +13,8 @@ mock! {
 
 #[test]
 fn returning() {
-    MockFoo::<u32>::expect_foo()
-        .returning(|_| ());
+    let ctx = MockFoo::<u32>::foo_context();
+    ctx.expect()
+        .returning(|_: u32| ());
     MockFoo::foo(42u32);
 }

--- a/mockall/tests/mock_static_method_with_generic_args.rs
+++ b/mockall/tests/mock_static_method_with_generic_args.rs
@@ -14,6 +14,7 @@ mock! {
 
 #[test]
 fn returning() {
-    MockFoo::expect_bar::<i16>().returning(|_| ());
+    let ctx = MockFoo::bar_context();
+    ctx.expect::<i16>().returning(|_| ());
     MockFoo::bar(0i16)
 }

--- a/mockall/tests/mock_static_method_with_generic_return.rs
+++ b/mockall/tests/mock_static_method_with_generic_return.rs
@@ -14,8 +14,8 @@ mock! {
 
 #[test]
 fn returning() {
-    MockFoo::expect_bar::<i16>()
-        .returning(|x| vec![x]);
+    let ctx = MockFoo::bar_context();
+    ctx.expect::<i16>().returning(|x| vec![x]);
     let v = MockFoo::bar(42i16);
     assert_eq!(v[0], 42i16);
 }

--- a/mockall/tests/mock_static_method_with_reference_arguments.rs
+++ b/mockall/tests/mock_static_method_with_reference_arguments.rs
@@ -10,7 +10,8 @@ mock!{
 
 #[test]
 fn with() {
-    MockFoo::expect_bar()
+    let ctx = MockFoo::bar_context();
+    ctx.expect()
         .with(predicate::eq(42))
         .return_const(99u64);
     assert_eq!(99, MockFoo::bar(&42));

--- a/mockall/tests/mock_struct_with_static_method.rs
+++ b/mockall/tests/mock_struct_with_static_method.rs
@@ -1,41 +1,95 @@
 // vim: tw=80
 
 use mockall::*;
+use std::sync::Mutex;
 
 mock!{
     Foo {
         fn bar(x: u32) -> u64;
-        fn baz(x: u16) -> u8;
     }
 }
 
+lazy_static! {
+    static ref BAR_MTX: Mutex<()> = Mutex::new(());
+}
+
+// Checkpointing the mock object should check static methods
 #[test]
 #[should_panic(expected =
     "MockFoo::bar: Expectation called fewer than 1 times")]
 fn checkpoint() {
+    let _m = BAR_MTX.lock();
+
     let mut mock = MockFoo::new();
-    MockFoo::expect_bar()
+    let ctx = MockFoo::bar_context();
+    ctx.expect()
         .returning(|_| 32)
         .times(1..3);
     mock.checkpoint();
     panic!("Shouldn't get here!");
 }
 
-// Until we get some kind of context for free functions, the return_default
-// feature won't work if there are any other tests that mock the same function.
-// https://github.com/asomers/mockall/issues/30
-#[cfg_attr(not(feature = "nightly"),
-           should_panic(expected = "Returning default values requires"))]
+// It should also be possible to checkpoint just the context object
+#[test]
+#[should_panic(expected =
+    "MockFoo::bar: Expectation called fewer than 1 times")]
+fn ctx_checkpoint() {
+    let _m = BAR_MTX.lock();
+
+    let ctx = MockFoo::bar_context();
+    ctx.expect()
+        .returning(|_| 32)
+        .times(1..3);
+    ctx.checkpoint();
+    panic!("Shouldn't get here!");
+}
+
+// Expectations should be cleared when a context object drops
+#[test]
+#[should_panic(expected = "No matching expectation found")]
+fn ctx_hygiene() {
+    let _m = BAR_MTX.lock();
+
+    {
+        let ctx0 = MockFoo::bar_context();
+        ctx0.expect()
+            .returning(|x| u64::from(x + 1));
+    }
+    MockFoo::bar(42);
+}
+
+#[cfg_attr(not(feature = "nightly"), ignore)]
 #[test]
 fn return_default() {
-    MockFoo::expect_baz();
-    let r = MockFoo::baz(5);
-    assert_eq!(u8::default(), r);
+    let _m = BAR_MTX.lock();
+
+    let ctx = MockFoo::bar_context();
+    ctx.expect();
+    let r = MockFoo::bar(5);
+    assert_eq!(u64::default(), r);
 }
 
 #[test]
 fn returning() {
-    MockFoo::expect_bar()
+    let _m = BAR_MTX.lock();
+
+    let ctx = MockFoo::bar_context();
+    ctx.expect()
         .returning(|x| u64::from(x + 1));
     assert_eq!(42, MockFoo::bar(41));
+}
+
+#[test]
+fn two_matches() {
+    let _m = BAR_MTX.lock();
+
+    let ctx = MockFoo::bar_context();
+    ctx.expect()
+        .with(predicate::eq(42))
+        .return_const(99u64);
+    ctx.expect()
+        .with(predicate::eq(69))
+        .return_const(101u64);
+    assert_eq!(101, MockFoo::bar(69));
+    assert_eq!(99, MockFoo::bar(42));
 }

--- a/mockall/tests/mock_trait_with_static_method.rs
+++ b/mockall/tests/mock_trait_with_static_method.rs
@@ -15,7 +15,8 @@ mock!{
 
 #[test]
 fn returning() {
-    MockFoo::expect_baz()
+    let ctx = MockFoo::baz_context();
+    ctx.expect()
         .returning(|x| u64::from(x + 1));
     assert_eq!(42, MockFoo::baz(41));
 }

--- a/mockall_derive/src/automock.rs
+++ b/mockall_derive/src/automock.rs
@@ -432,7 +432,7 @@ fn mock_function(vis: &Visibility, sig: &Signature) -> TokenStream {
         }
         #meth_vis fn #context_ident() -> #mod_ident::Context
         {
-            #mod_ident::Context{}
+            #mod_ident::Context::default()
         }
     ).to_tokens(&mut out);
     out

--- a/mockall_derive/src/expectation.rs
+++ b/mockall_derive/src/expectation.rs
@@ -923,6 +923,11 @@ impl<'a> StaticExpectation<'a> {
 
         if !self.common.is_generic() {
             quote!(
+                ::mockall::lazy_static! {
+                    #v static ref EXPECTATIONS:
+                        ::std::sync::Mutex<Expectations> =
+                        ::std::sync::Mutex::new(Expectations::new());
+                }
                 /// Like an [`&Expectation`](struct.Expectation.html) but
                 /// protected by a Mutex guard.  Useful for mocking static
                 /// methods.  Forwards accesses to an `Expectation` object.
@@ -1046,6 +1051,11 @@ impl<'a> StaticExpectation<'a> {
             )
         } else {
             quote!(
+                ::mockall::lazy_static! {
+                    #v static ref EXPECTATIONS:
+                        ::std::sync::Mutex<GenericExpectations> =
+                        ::std::sync::Mutex::new(GenericExpectations::new());
+                }
                 /// Like a [`ExpectationGuard`](struct.ExpectationGuard.html)
                 /// but for generic methods.
                 #v struct ExpectationGuard #lt_ig #lt_wc{

--- a/mockall_derive/src/mock.rs
+++ b/mockall_derive/src/mock.rs
@@ -288,10 +288,11 @@ fn gen_mock_method(mod_ident: Option<&syn::Ident>,
         #[cfg(any(test, not(feature = "extra-docs")))]
         let docstr: Option<syn::Attribute> = None;
         let context_ident = format_ident!("{}_context", ident);
+        let (_, ctx_tg, _) = generics.split_for_impl();
         quote!(#attrs #docstr #expect_vis fn #context_ident()
-               -> #mod_ident::#ident::Context
+               -> #mod_ident::#ident::Context #ctx_tg
             {
-                #mod_ident::#ident::Context{}
+                #mod_ident::#ident::Context::default()
             }
         )
     } else {

--- a/mockall_derive/src/mock.rs
+++ b/mockall_derive/src/mock.rs
@@ -300,16 +300,10 @@ fn gen_mock_method(mod_ident: Option<&syn::Ident>,
         let merged_g = merge_generics(&generics, &g);
         let (ig, _, _) = g.split_for_impl();
         let (_, tg, _) = merged_g.split_for_impl();
-        let guard_name = if !meth_types.is_expectation_generic {
-            format_ident!("ExpectationGuard")
-        } else {
-            format_ident!("GenericExpectationGuard")
-        };
         quote!(#attrs #docstr #expect_vis fn #expect_ident #ig()
-               -> #mod_ident::#ident::#guard_name #tg
-               #wc
+               -> #mod_ident::#ident::ExpectationGuard #tg #wc
             {
-                #mod_ident::#ident::#guard_name::new(#name.lock().unwrap())
+                #mod_ident::#ident::ExpectationGuard::new(#name.lock().unwrap())
             }
         )
     } else {


### PR DESCRIPTION
Add context objects for mocking static methods
    
This PR adds Context objects for static methods and free functions.  Expectations are still global, but the context object will clean up any global expectations when it drops.  This has a few benefits:
    
* Call counts will be verified when the context object drops
* The context object can be used to checkpoint its method
* "No matching expectation found" errors will no longer poison the static method's global mutex.  Panics in the returning method still will, however.
    
Fixes #30

CC @ArekPiekarz