### PR TITLE
Add some must_use warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased] - ReleaseDate
 ### Added
 
+- Warnings for misued expectations and context objects
+  ([#37](https://github.com/asomers/mockall/pull/37))
+
 - Methods with closure arguments and where clauses can now be mocked.
   ([#35](https://github.com/asomers/mockall/pull/35))
 

--- a/mockall/tests/mock_generic_struct_with_generic_static_method.rs
+++ b/mockall/tests/mock_generic_struct_with_generic_static_method.rs
@@ -60,6 +60,7 @@ fn ctx_hygiene() {
 }
 
 #[cfg_attr(not(feature = "nightly"), ignore)]
+#[cfg_attr(not(feature = "nightly"), allow(unused_must_use))]
 #[test]
 fn return_default() {
     let _m = BAR_MTX.lock();

--- a/mockall/tests/mock_generic_struct_with_nondefault_parameter.rs
+++ b/mockall/tests/mock_generic_struct_with_nondefault_parameter.rs
@@ -20,6 +20,7 @@ mock! {
 #[should_panic(expected =
     "Can only return default values for types that impl std::Default")]
 #[cfg_attr(not(feature = "nightly"), ignore)]
+#[cfg_attr(not(feature = "nightly"), allow(unused_must_use))]
 fn return_default() {
     let mut mock = MockExternalStruct::<NonDefault>::new();
     mock.expect_foo();

--- a/mockall/tests/mock_return_mutable_reference.rs
+++ b/mockall/tests/mock_return_mutable_reference.rs
@@ -12,6 +12,7 @@ mock! {
 #[test]
 #[cfg_attr(not(feature = "nightly"),
            should_panic(expected = "Returning default values requires"))]
+#[cfg_attr(not(feature = "nightly"), allow(unused_must_use))]
 fn return_default() {
     let mut mock = MockFoo::new();
     mock.expect_foo();

--- a/mockall/tests/mock_return_reference.rs
+++ b/mockall/tests/mock_return_reference.rs
@@ -43,6 +43,7 @@ fn return_const() {
 #[test]
 #[cfg_attr(not(feature = "nightly"),
            should_panic(expected = "Returning default values requires"))]
+#[cfg_attr(not(feature = "nightly"), allow(unused_must_use))]
 fn return_default() {
     let mut mock = MockFoo::new();
     mock.expect_foo();

--- a/mockall/tests/mock_struct.rs
+++ b/mockall/tests/mock_struct.rs
@@ -188,6 +188,7 @@ fn return_const() {
 
 #[cfg_attr(not(feature = "nightly"),
            should_panic(expected = "Returning default values requires"))]
+#[cfg_attr(not(feature = "nightly"), allow(unused_must_use))]
 #[test]
 fn return_default() {
     let mut mock = MockFoo::new();

--- a/mockall/tests/mock_struct_with_static_method.rs
+++ b/mockall/tests/mock_struct_with_static_method.rs
@@ -59,6 +59,7 @@ fn ctx_hygiene() {
 }
 
 #[cfg_attr(not(feature = "nightly"), ignore)]
+#[cfg_attr(not(feature = "nightly"), allow(unused_must_use))]
 #[test]
 fn return_default() {
     let _m = BAR_MTX.lock();

--- a/mockall_derive/src/expectation.rs
+++ b/mockall_derive/src/expectation.rs
@@ -949,6 +949,7 @@ impl<'a> StaticExpectation<'a> {
         };
 
         let context_ts = quote!(
+            #[must_use = "Context only serves to create expectations" ]
             #v struct Context #s_ig #s_wc {
                 // Prevent "unused type parameter" errors
                 // Surprisingly, PhantomData<Fn(generics)> is Send even if
@@ -970,6 +971,9 @@ impl<'a> StaticExpectation<'a> {
                         .collect::<Vec<_>>();
                 }
 
+                #[cfg_attr(not(feature = "nightly"), must_use =
+                    "Must set return value when not using the \"nightly\" feature")
+                ]
                 #v fn expect #meth_ig ( &self,) -> ExpectationGuard #e_tg
                     #meth_wc
                 {

--- a/mockall_derive/src/mock.rs
+++ b/mockall_derive/src/mock.rs
@@ -305,12 +305,17 @@ fn gen_mock_method(mod_ident: Option<&syn::Ident>,
         #[cfg(any(test, not(feature = "extra-docs")))]
         let docstr: Option<syn::Attribute> = None;
         let expect_ident = format_ident!("expect_{}", ident);
-        quote!(#attrs #docstr #expect_vis fn #expect_ident #ig(&mut self)
+        quote!(
+            #[cfg_attr(not(feature = "nightly"), must_use =
+                "Must set return value when not using the \"nightly\" feature")
+            ]
+            #attrs #docstr #expect_vis fn #expect_ident #ig(&mut self)
                -> &mut #mod_ident::#expectation
                #wc
-        {
-            #expect_obj_name.expect#call_turbofish()
-        })
+            {
+                #expect_obj_name.expect#call_turbofish()
+            }
+        )
     }.to_tokens(&mut expect_output);
 
     // Finally this method's contribution to the checkpoint method


### PR DESCRIPTION
There's no good reason to create a Context object but not set any
expectations.  And when the "nightly" feature is off, there's no good
reason to create an expectation but not set its return value.  Warn the
user if he does one of those things.

Suggested by @ArekPiekarz