### PR TITLE
Fix mocking methods that return &'static str

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- Fixed mocking methods that return `'static` deref types, like `&'static str`
+  ([#39](https://github.com/asomers/mockall/pull/39))
+
 - Methods returning non-`'static` references (mutable or otherwise) will now
   return a default value if no return value is set, if the output type
   implements `Default` and the `nightly` feature is enabled.  This more closely

--- a/mockall/tests/automock_deref.rs
+++ b/mockall/tests/automock_deref.rs
@@ -13,6 +13,7 @@ trait Foo {
     fn alias(&self) -> &str;
     fn desc(&self) -> &OsStr;
     fn path(&self) -> &Path;
+    fn text(&self) -> &'static str;
 }
 
 mod return_const {
@@ -50,5 +51,13 @@ mod return_const {
         let mut mock = MockFoo::new();
         mock.expect_alias().return_const("abcd".to_owned());
         assert_eq!("abcd", mock.alias());
+    }
+
+    #[test]
+    fn static_str() {
+        const TEXT: &'static str = "abcd";
+        let mut mock = MockFoo::new();
+        mock.expect_text().return_const(TEXT);
+        assert_eq!("abcd", mock.text());
     }
 }

--- a/mockall_derive/src/expectation.rs
+++ b/mockall_derive/src/expectation.rs
@@ -7,6 +7,15 @@ use quote::ToTokens;
 /// type like "&String".
 fn destrify(ty: &mut Type) {
     if let Type::Reference(ref mut tr) = ty {
+        if let Some(lt) = &tr.lifetime {
+            if lt.ident == "static" {
+                // For methods that return 'static references, the user can
+                // usually actually supply one, unlike nonstatic references.
+                // destrify is unneeded and harmful in such cases.
+                return;
+            }
+        }
+
         let path_ty: TypePath = parse2(quote!(Path)).unwrap();
         let pathbuf_ty: Type = parse2(quote!(::std::path::PathBuf)).unwrap();
 


### PR DESCRIPTION
Don't perform the deref conversion when mocking methods that return
&'static references

Fixes #38