### PR TITLE
Better panics2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 - Reexport more traits from the predicates crate
-  ([#42](https://github.com/asomers/mockall/pull/42))
+  ([09746e9](https://github.com/asomers/mockall/commit/09746e92d4a7a904b1911babbe65cc1043e237d4))
 
 ### Changed
 ### Fixed

--- a/mockall/src/lib.rs
+++ b/mockall/src/lib.rs
@@ -1264,6 +1264,7 @@ pub struct TimesRange(Range<usize>);
 
 impl Default for TimesRange {
     fn default() -> TimesRange {
+        // By default, allow any number of calls
         TimesRange(0..usize::max_value())
     }
 }
@@ -1312,12 +1313,11 @@ impl From<RangeToInclusive<usize>> for TimesRange {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 #[doc(hidden)]
 pub struct Times{
     /// How many times has the expectation already been called?
     count: AtomicUsize,
-    name: String,
     range: TimesRange
 }
 
@@ -1370,15 +1370,6 @@ impl Times {
 
     pub fn never(&mut self) {
         self.range.0 = 0..1;
-    }
-
-    pub fn new<S: Into<String>>(name: S) -> Times {
-        // By default, allow any number of calls
-        Times {
-            count: AtomicUsize::default(),
-            name: name.into(),
-            range: TimesRange::default(),
-        }
     }
 
     pub fn range(&mut self, range: Range<usize>) {

--- a/mockall/tests/automock_foreign_c.rs
+++ b/mockall/tests/automock_foreign_c.rs
@@ -9,6 +9,16 @@ extern "C" {
 }
 
 #[test]
+#[should_panic(expected = "mock_ffi::foo: No matching expectation found")]
+fn with_no_matches() {
+    let ctx = mock_ffi::foo_context();
+    ctx.expect()
+        .with(predicate::eq(4))
+        .returning(i64::from);
+    unsafe{ mock_ffi::foo(5) };
+}
+
+#[test]
 fn returning() {
     let ctx = mock_ffi::foo_context();
     ctx.expect().returning(i64::from);

--- a/mockall/tests/automock_module.rs
+++ b/mockall/tests/automock_module.rs
@@ -19,6 +19,16 @@ cfg_if! {
             }
 
             #[test]
+            #[should_panic(expected = "mock_foo::bar: No matching expectation found")]
+            fn with_no_matches() {
+                let ctx = mock_foo::bar_context();
+                ctx.expect()
+                    .with(predicate::eq(4))
+                    .return_const(0);
+                mock_foo::bar(5);
+            }
+
+            #[test]
             fn returning() {
                 let ctx = mock_foo::bar_context();
                 ctx.expect()

--- a/mockall/tests/automock_slice_arguments.rs
+++ b/mockall/tests/automock_slice_arguments.rs
@@ -12,7 +12,7 @@ mod withf {
     use super::*;
 
     #[test]
-    #[should_panic(expected = "No matching expectation found")]
+    #[should_panic(expected = "MockFoo::foo: No matching expectation found")]
     fn fail() {
         let mut mock = MockFoo::new();
         mock.expect_foo()

--- a/mockall/tests/mock_generic_arguments.rs
+++ b/mockall/tests/mock_generic_arguments.rs
@@ -51,7 +51,7 @@ mod with {
     }
 
     #[test]
-    #[should_panic(expected = "No matching expectation found")]
+    #[should_panic(expected = "MockFoo::foo: No matching expectation found")]
     fn wrong_generic_type() {
         let mut mock = MockFoo::new();
         mock.expect_foo::<i16>()

--- a/mockall/tests/mock_generic_struct_with_generic_static_method.rs
+++ b/mockall/tests/mock_generic_struct_with_generic_static_method.rs
@@ -47,7 +47,7 @@ fn ctx_checkpoint() {
 
 // Expectations should be cleared when a context object drops
 #[test]
-#[should_panic(expected = "No matching expectation found")]
+#[should_panic(expected = "MockFoo::foo: No matching expectation found")]
 fn ctx_hygiene() {
     let _m = BAR_MTX.lock();
 

--- a/mockall/tests/mock_struct.rs
+++ b/mockall/tests/mock_struct.rs
@@ -63,7 +63,7 @@ mod checkpoint {
     }
 
     #[test]
-    #[should_panic(expected = "No matching expectation found")]
+    #[should_panic(expected = "MockFoo::foo: No matching expectation found")]
     fn removes_old_expectations() {
         let mut mock = MockFoo::new();
         mock.expect_foo()
@@ -117,7 +117,7 @@ mod r#match {
     }
 
     #[test]
-    #[should_panic(expected = "No matching expectation found")]
+    #[should_panic(expected = "MockFoo::bar: No matching expectation found")]
     fn with_no_matches() {
         let mut mock = MockFoo::new();
         mock.expect_bar()
@@ -145,7 +145,7 @@ mod r#match {
     }
 
     #[test]
-    #[should_panic(expected = "No matching expectation found")]
+    #[should_panic(expected = "MockFoo::bar: No matching expectation found")]
     fn withf_no_matches() {
         let mut mock = MockFoo::new();
         mock.expect_bar()

--- a/mockall/tests/mock_struct_with_static_method.rs
+++ b/mockall/tests/mock_struct_with_static_method.rs
@@ -46,7 +46,7 @@ fn ctx_checkpoint() {
 
 // Expectations should be cleared when a context object drops
 #[test]
-#[should_panic(expected = "No matching expectation found")]
+#[should_panic(expected = "MockFoo::bar: No matching expectation found")]
 fn ctx_hygiene() {
     let _m = BAR_MTX.lock();
 

--- a/mockall_derive/src/expectation.rs
+++ b/mockall_derive/src/expectation.rs
@@ -411,7 +411,7 @@ impl<'a> Expectation<'a> {
                     Common {
                         matcher: Mutex::new(Matcher::default()),
                         seq_handle: None,
-                        times: ::mockall::Times::new(#ident_str)
+                        times: ::mockall::Times::default()
                     }
                 }
             }


### PR DESCRIPTION
"No matching expectation found" panic messages now include the method name.