### PR TITLE
Allow mocking generic methods with lifetime parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+- Many generic methods with lifetime parameters can now be mocked.  The
+  condition is that they may not also have generic type parameters, and their
+  return values must be `'static`.
+  ([#48](https://github.com/asomers/mockall/pull/48))
+
 - Reexport more traits from the predicates crate
   ([09746e9](https://github.com/asomers/mockall/commit/09746e92d4a7a904b1911babbe65cc1043e237d4))
 

--- a/mockall/src/lib.rs
+++ b/mockall/src/lib.rs
@@ -37,6 +37,7 @@
 //! * [`impl Trait`](#impl-trait)
 //! * [`Mocking structs`](#mocking-structs)
 //! * [`Generic methods`](#generic-methods)
+//! * [`Methods with generic lifetimes`](#methods-with-generic-lifetimes)
 //! * [`Generic traits and structs`](#generic-traits-and-structs)
 //! * [`Associated types`](#associated-types-1)
 //! * [`Multiple and inherited traits`](#multiple-and-inherited-traits)
@@ -626,7 +627,7 @@
 //! infinite set of regular methods, and each of those works just like any other
 //! regular method.  The expect_* method is generic, too, and usually must be
 //! called with a turbofish.  The only restrictions on mocking generic methods
-//! are that each generic parameter must be `'static`, and generic lifetime
+//! are that all generic parameters must be `'static`, and generic lifetime
 //! parameters are not allowed.
 //!
 //! ```
@@ -644,6 +645,36 @@
 //!
 //! assert_eq!(5, mock.foo(5i16));
 //! assert_eq!(-5, mock.foo(5i8));
+//! ```
+//!
+//! ## Methods with generic lifetimes
+//!
+//! A method with a lifetime parameter is technically a generic method, but
+//! Mockall treats it like a non-generic method that must work for all possible
+//! lifetimes.  Mocking such a method is similar to mocking a non-generic
+//! method, with a few additional restrictions.  One restriction is that you
+//! can't match calls with `with`, you must use `withf` instead.  Another is
+//! that the generic lifetime may not appear as part of the return type.
+//! Finally, no method may have both generic lifetime parameters *and* generic
+//! type parameters.
+//!
+//! ```
+//! # use mockall::*;
+//! struct X<'a>(&'a i32);
+//!
+//! #[automock]
+//! trait Foo {
+//!     fn foo<'a>(&self, x: X<'a>) -> i32;
+//! }
+//!
+//! # fn main() {
+//! let mut mock = MockFoo::new();
+//! mock.expect_foo()
+//!     .withf(|f| *f.0 == 5)
+//!     .return_const(42);
+//! let x = X(&5);
+//! assert_eq!(42, mock.foo(x));
+//! # }
 //! ```
 //!
 //! ## Generic traits and structs

--- a/mockall/tests/automock_generic_method_with_lifetime_parameter.rs
+++ b/mockall/tests/automock_generic_method_with_lifetime_parameter.rs
@@ -1,0 +1,47 @@
+// vim: tw=80
+//! A generic method whose only generic parameter is a lifetime parameter is,
+//! from Mockall's perspective, pretty much the same as a non-generic method.
+
+use mockall::*;
+
+#[derive(Debug, Eq)]
+struct X<'a>(&'a u32);
+
+impl<'a> PartialEq for X<'a> {
+    fn eq(&self, other: &X<'a>) -> bool {
+        self.0 == other.0
+    }
+}
+
+#[automock]
+trait Foo {
+    fn foo<'a>(&self, x: &'a X<'a>) -> u32;
+}
+
+#[test]
+fn return_const() {
+    let mut mock = MockFoo::new();
+    mock.expect_foo()
+        .return_const(42u32);
+    let x = X(&5);
+    assert_eq!(42, mock.foo(&x));
+}
+
+#[test]
+fn returning() {
+    let mut mock = MockFoo::new();
+    mock.expect_foo()
+        .returning(|f| *f.0);
+    let x = X(&5);
+    assert_eq!(5, mock.foo(&x));
+}
+
+#[test]
+fn withf() {
+    let mut mock = MockFoo::new();
+    mock.expect_foo()
+        .withf(|f| *f.0 == 5)
+        .return_const(42u32);
+    let x = X(&5);
+    assert_eq!(42, mock.foo(&x));
+}

--- a/mockall/tests/mock_generic_method_with_lifetime_parameter.rs
+++ b/mockall/tests/mock_generic_method_with_lifetime_parameter.rs
@@ -1,0 +1,64 @@
+// vim: tw=80
+//! A generic method whose only generic parameter is a lifetime parameter is,
+//! from Mockall's perspective, pretty much the same as a non-generic method.
+
+use mockall::*;
+
+#[derive(Debug, Eq)]
+struct X<'a>(&'a u32);
+
+impl<'a> PartialEq for X<'a> {
+    fn eq(&self, other: &X<'a>) -> bool {
+        self.0 == other.0
+    }
+}
+
+mock!{
+    Foo {
+        fn foo<'a>(&self, x: &'a X<'a>) -> u32;
+    }
+}
+
+#[test]
+fn return_const() {
+    let mut mock = MockFoo::new();
+    mock.expect_foo()
+        .return_const(42u32);
+    let x = X(&5);
+    assert_eq!(42, mock.foo(&x));
+}
+
+#[test]
+fn returning() {
+    let mut mock = MockFoo::new();
+    mock.expect_foo()
+        .returning(|f| *f.0);
+    let x = X(&5);
+    assert_eq!(5, mock.foo(&x));
+}
+
+// I can't get this to work.  How can I create a Predicate that's valid for all
+// lifetimes?  'static should be reduceable to any other lifetime, but rustc
+// doesn't seem to understand that.
+//#[test]
+//fn with() {
+    //const X1: u32 = 5;
+    //const OTHER: X<'static> = X(&X1);
+    //let mut mock = MockFoo::new();
+    //mock.expect_foo()
+        //.with(mockall::predicate::eq(&OTHER))
+        //.return_const(42u32);
+    //let inner = 5;
+    //let x = X(&5);
+    //assert_eq!(42, mock.foo(&x));
+//}
+
+#[test]
+fn withf() {
+    let mut mock = MockFoo::new();
+    mock.expect_foo()
+        .withf(|f| *f.0 == 5)
+        .return_const(42u32);
+    let x = X(&5);
+    assert_eq!(42, mock.foo(&x));
+}

--- a/mockall/tests/mock_static_method_with_lifetime_parameters.rs
+++ b/mockall/tests/mock_static_method_with_lifetime_parameters.rs
@@ -1,0 +1,58 @@
+// vim: tw=80
+//! A static generic method whose only generic parameter is a lifetime parameter
+
+use mockall::*;
+use std::sync::Mutex;
+
+#[derive(Debug, Eq)]
+struct X<'a>(&'a u32);
+
+impl<'a> PartialEq for X<'a> {
+    fn eq(&self, other: &X<'a>) -> bool {
+        self.0 == other.0
+    }
+}
+
+mock!{
+    Foo {
+        fn foo<'a>(x: &'a X<'a>) -> u32;
+    }
+}
+
+lazy_static! {
+    static ref FOO_MTX: Mutex<()> = Mutex::new(());
+}
+
+#[test]
+fn return_const() {
+    let _m = FOO_MTX.lock().unwrap();
+
+    let ctx = MockFoo::foo_context();
+    ctx.expect()
+        .return_const(42u32);
+    let x = X(&5);
+    assert_eq!(42, MockFoo::foo(&x));
+}
+
+#[test]
+fn returning() {
+    let _m = FOO_MTX.lock().unwrap();
+
+    let ctx = MockFoo::foo_context();
+    ctx.expect()
+        .returning(|f| *f.0);
+    let x = X(&5);
+    assert_eq!(5, MockFoo::foo(&x));
+}
+
+#[test]
+fn withf() {
+    let _m = FOO_MTX.lock().unwrap();
+
+    let ctx = MockFoo::foo_context();
+    ctx.expect()
+        .withf(|f| *f.0 == 5)
+        .return_const(42u32);
+    let x = X(&5);
+    assert_eq!(42, MockFoo::foo(&x));
+}

--- a/mockall_derive/src/automock.rs
+++ b/mockall_derive/src/automock.rs
@@ -66,8 +66,10 @@ impl Attrs {
                             self.substitute_type(&mut binding.ty);
                         },
                         _ => {
-                            compile_error(arg.span(),
-                                "Mockall does not yet support this argument type in this position");
+                            /*
+                             * Nothing to do, as long as lifetimes can't be
+                             * associated types
+                             */
                         }
                     }
                 }

--- a/mockall_derive/src/expectation.rs
+++ b/mockall_derive/src/expectation.rs
@@ -840,7 +840,6 @@ impl<'a> StaticExpectation<'a> {
                 }
 
             }
-            impl #ig ::mockall::AnyExpectations for Expectations #tg #wc {}
         )
     }
 
@@ -860,6 +859,7 @@ impl<'a> StaticExpectation<'a> {
         let tbf = tg.as_turbofish();
         let v = &self.common.vis;
         quote!(
+            impl #ig ::mockall::AnyExpectations for Expectations #tg #wc {}
             impl GenericExpectations {
                 /// Simulating calling the real method.
                 #v fn call #ig (&self, #(#argnames: #argty, )* )
@@ -1457,11 +1457,6 @@ impl<'a> RefExpectation<'a> {
                         )
                 }
             }
-            // The Senc + Sync are required for downcast, since Expectation
-            // stores an Option<#output>
-            impl #ig ::mockall::AnyExpectations for Expectations #tg
-                    where #output: Send + Sync
-            {}
         )
     }
 
@@ -1476,6 +1471,11 @@ impl<'a> RefExpectation<'a> {
         let v = &self.common.vis;
 
         quote!(
+            // The Senc + Sync are required for downcast, since Expectation
+            // stores an Option<#output>
+            impl #ig ::mockall::AnyExpectations for Expectations #tg
+                    where #output: Send + Sync
+            {}
             impl GenericExpectations {
                 /// Simulating calling the real method.
                 #v fn call #ig (&self, #(#argnames: #argty,)*)


### PR DESCRIPTION
Now it's possible to mock generic methods with lifetime parameters, as long as they don't also have type parameters, and their return values are `'static` or have the same lifetime as `self`.

@michaelmarconi does this work for you?