### PR TITLE
Fix using super:: in the signature of a bare function with automock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 ### Fixed
 
+- Fixed using super:: in the signature of a bare function
+  ([#54](https://github.com/asomers/mockall/pull/54))
+
 - Fixed automocking modules that contain use statements importing types that
   are used in function signatures.
   ([#53](https://github.com/asomers/mockall/pull/53))

--- a/mockall/tests/automock_module_nonpub.rs
+++ b/mockall/tests/automock_module_nonpub.rs
@@ -1,0 +1,36 @@
+// vim: tw=80
+//! bare functions can use non-public types, as long as the object's visibility is compatible.
+
+// mocking modules requires the proc_macro_hygiene feature in the _consumer_
+// code
+#![cfg_attr(feature = "nightly", feature(proc_macro_hygiene))]
+
+#[allow(unused)]
+cfg_if::cfg_if! {
+    if #[cfg(feature = "nightly")] {
+        mod outer {
+            struct SuperT();
+
+            mod inner {
+                use mockall::automock;
+
+                pub(crate) struct PubCrateT();
+                struct PrivT();
+
+                #[automock]
+                mod m {
+                    use super::*;
+
+                    fn foo(x: PubCrateT) -> PubCrateT { unimplemented!() }
+                    fn bar(x: PrivT) -> PrivT { unimplemented!() }
+                    fn baz(x: super::super::SuperT) -> super::super::SuperT {
+                        unimplemented!()
+                    }
+                    fn bang(x: crate::outer::SuperT) -> crate::outer::SuperT {
+                        unimplemented!()
+                    }
+                }
+            }
+        }
+    }
+}

--- a/mockall_derive/src/automock.rs
+++ b/mockall_derive/src/automock.rs
@@ -416,7 +416,7 @@ fn mock_function(modname: &Ident, vis: &Visibility, sig: &Signature)
 
     let mut out = TokenStream::new();
     Expectation::new(&TokenStream::new(), &inputs, None, generics,
-        &ident, &mod_ident, None, &sig.output, &expect_vis)
+        &ident, &mod_ident, None, &sig.output, &expect_vis, 1)
         .to_tokens(&mut out);
     let no_match_msg = format!("{}::{}: No matching expectation found",
         modname, ident);

--- a/mockall_derive/src/expectation.rs
+++ b/mockall_derive/src/expectation.rs
@@ -577,6 +577,7 @@ impl<'a> Expectation<'a> {
     /// * `parent_ident`    - Name of the parent struct, if any.
     /// * `return_type`     - Return type of the mock method
     /// * `vis`             - Visibility of the expectation, *already supersuperfied*.
+    /// * `levels`          - Depth of modules added by the caller
     pub(crate) fn new(
         attrs: &'a TokenStream,
         args: &Punctuated<FnArg, Token![,]>,
@@ -586,7 +587,8 @@ impl<'a> Expectation<'a> {
         mod_ident: &'a Ident,
         parent_ident: Option<&'a Ident>,
         return_type: &ReturnType,
-        vis: &Visibility) -> Self
+        vis: &Visibility,
+        levels: i32) -> Self
     {
         // Too bad Iterator::unzip only works on 2-tuples
         let mut argnames = Vec::new();
@@ -597,7 +599,7 @@ impl<'a> Expectation<'a> {
         for fa in args.iter() {
             if let FnArg::Typed(pt) = fa {
                 let argname = (*pt.pat).clone();
-                let aty = supersuperfy(&pt.ty);
+                let aty = supersuperfy(&pt.ty, levels);
                 if let Type::Reference(ref tr) = aty {
                     predexprs.push(quote!(#argname));
                     predty.push((*tr.elem).clone());
@@ -658,7 +660,7 @@ impl<'a> Expectation<'a> {
                     rt
                 }
             }
-        });
+        }, levels);
 
         let common = Common {
             argnames,

--- a/mockall_derive/src/mock.rs
+++ b/mockall_derive/src/mock.rs
@@ -387,7 +387,7 @@ fn gen_struct<T>(mock_ident: &syn::Ident,
         Expectation::new(&attrs, &meth_types.expectation_inputs,
                          Some(&generics), &meth_types.expectation_generics,
                          meth_ident, meth_ident, Some(&mock_ident), output,
-                         &expect_vis).to_tokens(&mut mod_body);
+                         &expect_vis, 2).to_tokens(&mut mod_body);
 
         if !meth_types.is_static {
             quote!(#attrs #method_ident: #mod_ident::#expect_obj,)


### PR DESCRIPTION
Fixes #53