### PR TITLE
Unhack proc macros' doc comments

### DIFF
--- a/mockall_derive/src/lib.rs
+++ b/mockall_derive/src/lib.rs
@@ -733,17 +733,11 @@ fn method_types(sig: &Signature, generics: Option<&Generics>) -> MethodTypes {
                 expect_obj, call_exprs, inputs, output}
 }
 
-/// Manually mock a structure.
-///
-/// See detailed docs in [`mock`](https://docs.rs/mockall/latest/mockall/macro.mock.html).
 #[proc_macro]
 pub fn mock(item: proc_macro::TokenStream) -> proc_macro::TokenStream {
     do_mock(item.into()).into()
 }
 
-/// Automatically generate mock types for structs and traits.
-///
-/// See detailed docs in [`automock`](https://docs.rs/mockall/latest/mockall/macro.automock.html).
 #[proc_macro_attribute]
 pub fn automock(attrs: proc_macro::TokenStream, input: proc_macro::TokenStream)
     -> proc_macro::TokenStream


### PR DESCRIPTION
Previous versions of rustdoc did not allow adding doc comments to a
reexported proc macro, so mockall had to document fake locally-defined
macros with the same names as mockall_derive's proc macros.

That limitation is fixed as of rustc 1.40.0-nightly (084beb83e
2019-09-27), so we can remove the hack and put the doc comments where
they belong.

Fixes #42