### PR TITLE
Use `slice::iter` instead of `into_iter` to avoid future breakage

### DIFF
--- a/mockall_derive/src/expectation.rs
+++ b/mockall_derive/src/expectation.rs
@@ -399,7 +399,7 @@ impl<'a> Expectation<'a> {
                             __mockall_f(#(#argnames, )*),
                         Matcher::Pred(__mockall_pred) =>
                             [#pred_matches]
-                            .into_iter()
+                            .iter()
                             .all(|__mockall_x| *__mockall_x),
                         _ => unreachable!()
                     }


### PR DESCRIPTION
`an_array.into_iter()` currently just works because of the autoref
feature, which then calls `<[T] as IntoIterator>::into_iter`. But
in the future, arrays will implement `IntoIterator`, too. In order
to avoid problems in the future, the call is replaced by `iter()`
which is shorter and more explicit.

A crater run showed that your crate is affected by a potential future 
change. See https://github.com/rust-lang/rust/pull/65819 for more information.