### PR TITLE
Mock objects' checkpoint methods no longer check static expectations.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased] - ReleaseDate
 ### Added
 ### Changed
+
+- Mock objects' checkpoint methods will no longer check static expectations.
+  This behavior is more useful where static and regular methods are both used
+  in the same test.  The old behavior was a relic from release 0.3.0 and
+  before, when static methods did not yet have Context objects of their own.
+  ([#64](https://github.com/asomers/mockall/pull/64))
+
 ### Fixed
 
 - Fixed hygiene violations in some of mockall_derive's warnings.

--- a/mockall/src/lib.rs
+++ b/mockall/src/lib.rs
@@ -874,21 +874,29 @@
 //! ctx.checkpoint();   // Panics!
 //! ```
 //!
-//! A mock object's checkpoint method works for static methods, too.
+//! A mock object's checkpoint method does *not* checkpoint static methods.
+//! This behavior is useful when using multiple mock objects at once.  For
+//! example:
 //!
-//! ```should_panic
+//! ```
 //! # use mockall::*;
 //! #[automock]
 //! pub trait A {
-//!     fn foo() -> u32;
+//!     fn build() -> Self;
+//!     fn bar(&self) -> i32;
 //! }
 //!
-//! let mut mock = MockA::new();
-//! let ctx = MockA::foo_context();
+//! # fn main() {
+//! let ctx = MockA::build_context();
 //! ctx.expect()
-//!     .times(1)
-//!     .returning(|| 99);
-//! mock.checkpoint();  // Also panics!
+//!     .times(2)
+//!     .returning(|| MockA::default());
+//! let mut mock0 = MockA::build();
+//! mock0.expect_bar().return_const(4);
+//! mock0.bar();
+//! mock0.checkpoint();     // Does not checkpoint the build method
+//! let mock1 = MockA::build();
+//! # }
 //! ```
 //!
 //! One more thing: Mockall normally creates a zero-argument `new` method for

--- a/mockall/tests/mock_struct_with_static_method.rs
+++ b/mockall/tests/mock_struct_with_static_method.rs
@@ -7,7 +7,6 @@ mock!{
     Foo {
         fn bar(x: u32) -> u64;
         // We must have a separate method for every should_panic test
-        fn bar1(x: u32) -> u64;
         fn bar2(x: u32) -> u64;
         fn bar3(x: u32) -> u64;
     }
@@ -17,18 +16,18 @@ lazy_static! {
     static ref BAR_MTX: Mutex<()> = Mutex::new(());
 }
 
-// Checkpointing the mock object should check static methods
+// Checkpointing the mock object should not checkpoint static methods
 #[test]
-#[should_panic(expected =
-    "MockFoo::bar1: Expectation(<anything>) called fewer than 1 times")]
 fn checkpoint() {
+    let _m = BAR_MTX.lock().unwrap();
+
     let mut mock = MockFoo::new();
-    let ctx = MockFoo::bar1_context();
+    let ctx = MockFoo::bar_context();
     ctx.expect()
         .returning(|_| 32)
         .times(1..3);
     mock.checkpoint();
-    panic!("Shouldn't get here!");
+    MockFoo::bar(0);
 }
 
 // It should also be possible to checkpoint just the context object

--- a/mockall_derive/src/mock.rs
+++ b/mockall_derive/src/mock.rs
@@ -335,11 +335,9 @@ fn gen_mock_method(mock_struct_name: &syn::Ident,
 
     // Finally this method's contribution to the checkpoint method
     if meth_types.is_static {
-        quote!(#attrs {
-            let _timeses = #mod_ident::#ident::EXPECTATIONS.lock().unwrap()
-                .checkpoint()
-                .collect::<Vec<_>>();
-        })
+        // Don't checkpoint static methods.  They get checkpointed by their
+        // context objects instead.
+        quote!()
     } else {
         quote!(#attrs { #expect_obj_name.checkpoint(); })
     }.to_tokens(&mut cp_output);


### PR DESCRIPTION
This behavior is more useful where static and regular methods are both
used in the same test.  The old behavior was a relic from release 0.3.0
and before, when static methods did not yet have Context objects of
their own.

This commit also fixes intermittent test failures in
mock_generic_struct_with_generic_static_method and
mock_struct_with_static_method.  Those tests were failing because the
mock objects' checkpoints from one test were unexpectedly interfering
with static methods expectations' from other tests.