### PR TITLE
Fix the syntax in the doc test for mocking modules

### DIFF
--- a/mockall/src/lib.rs
+++ b/mockall/src/lib.rs
@@ -988,7 +988,8 @@
 //!
 //!     #[test]
 //!     fn test_foo_bar() {
-//!         inner::expect_bar()
+//!         let ctx = inner::bar_context();
+//!         ctx.expect()
 //!             .returning(|x| i64::from(x + 1));
 //!         assert_eq!(5, inner::bar(4));
 //!     }


### PR DESCRIPTION
Unfortunately little of this test actually gets executed because doc
tests are always built without #[cfg(test)]