### PR TITLE
Fix mocking methods when a custom Result type is in-scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased] - ReleaseDate
+### Added
+### Changed
+### Fixed
+
+- Fixed mocking methods when a custom `Result` type is in-scope.
+  ([#74](https://github.com/asomers/mockall/pull/74))
+
+### Removed
+
 ## [0.5.2] - 2 November 2019
 ### Added
 ### Changed

--- a/mockall/tests/automock_custom_result.rs
+++ b/mockall/tests/automock_custom_result.rs
@@ -1,0 +1,41 @@
+// vim: tw=80
+//! It should be possible to use a custom Result type in the signature of a
+//! mocked method.  Regression test for
+//! https://github.com/asomers/mockall/issues/73
+
+use mockall::*;
+
+pub type Result<T> = std::result::Result<T, String>;
+
+pub struct MyStruct {}
+
+#[automock]
+impl MyStruct {
+    pub fn ret_static(&self) -> Result<i32> { unimplemented!() }
+    pub fn ret_ref(&self) -> &Result<i32> { unimplemented!() }
+    pub fn ret_refmut(&mut self) -> &mut Result<i32> { unimplemented!() }
+}
+
+#[test]
+fn ret_ref() {
+    let mut s = MockMyStruct::new();
+    s.expect_ret_ref()
+        .return_const(Ok(42));
+    assert_eq!(Ok(42), *s.ret_ref());
+}
+
+#[test]
+fn ret_ref_mut() {
+    let mut s = MockMyStruct::new();
+    s.expect_ret_refmut()
+        .return_var(Ok(42));
+    assert_eq!(Ok(42), *s.ret_refmut());
+}
+
+#[test]
+fn ret_static() {
+    let mut s = MockMyStruct::new();
+    s.expect_ret_static()
+        .return_const(Ok(42));
+    assert_eq!(Ok(42), s.ret_static());
+}

--- a/mockall_derive/src/expectation.rs
+++ b/mockall_derive/src/expectation.rs
@@ -961,7 +961,7 @@ impl<'a> StaticExpectation<'a> {
 
             impl #ig  Rfunc #tg #wc {
                 fn call_mut #lg (&mut self, #( #argnames: #argty, )* )
-                    -> Result<#output, &'static str>
+                    -> std::result::Result<#output, &'static str>
                 {
                     match self {
                         Rfunc::Default => {
@@ -1612,7 +1612,9 @@ impl<'a> RefExpectation<'a> {
             }
 
             impl #ig  Rfunc #tg #wc {
-                fn call #lg (&self) -> Result<&#output, &'static str> {
+                fn call #lg (&self)
+                    -> std::result::Result<&#output, &'static str>
+                {
                     match self {
                         Rfunc::Default(Some(ref __mockall_o)) => {
                             Ok(__mockall_o)
@@ -1844,7 +1846,7 @@ impl<'a> RefMutExpectation<'a> {
 
             impl #ig  Rfunc #tg #wc {
                 fn call_mut #lg (&mut self, #(#argnames: #argty, )*)
-                    -> Result<&mut #output, &'static str>
+                    -> std::result::Result<&mut #output, &'static str>
                 {
                     match self {
                         Rfunc::Default(Some(ref mut __mockall_o)) => {


### PR DESCRIPTION
There was a hygiene violation in the proc macro.  It would cause
automock and mock to fail anytime a custom Result type was in scope,
even if the mocked method didn't try to use it.

Fixes #73