### PR TITLE
Update predicates to 1.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 ### Fixed
 
+- Fixed using `prediate::always` and `prediate::never` with `?Sized` types
+  ([#80](https://github.com/asomers/mockall/pull/80))
+
 - Fixed mocking methods when a custom `Result` type is in-scope.
   ([#74](https://github.com/asomers/mockall/pull/74))
 

--- a/mockall/Cargo.toml
+++ b/mockall/Cargo.toml
@@ -25,6 +25,6 @@ cfg-if = "0.1.6"
 downcast = "0.10"
 fragile = "0.3"
 lazy_static = "1.1"
-predicates = "1.0.1"
+predicates = "1.0.2"
 predicates-tree = "1.0"
 mockall_derive = { version = "= 0.5.2", path = "../mockall_derive" }

--- a/mockall/tests/mock_unsized.rs
+++ b/mockall/tests/mock_unsized.rs
@@ -1,0 +1,51 @@
+// vim: tw=80
+//! All types of predicate should work for methods with unsized arguments
+
+use mockall::*;
+
+mock! {
+    Foo {
+        fn foo(&self, arg: &str);
+    }
+}
+
+#[test]
+fn with_always() {
+    let mut foo = MockFoo::new();
+    foo.expect_foo()
+        .with(predicate::always())
+        .return_const(());
+
+    foo.foo("xxx");
+}
+
+#[test]
+fn with_eq() {
+    let mut foo = MockFoo::new();
+    foo.expect_foo()
+        .with(predicate::eq("xxx"))
+        .return_const(());
+
+    foo.foo("xxx");
+}
+
+#[test]
+#[should_panic(expected = "MockFoo::foo: No matching expectation found")]
+fn with_never() {
+    let mut foo = MockFoo::new();
+    foo.expect_foo()
+        .with(predicate::never())
+        .return_const(());
+
+    foo.foo("xxx");
+}
+
+#[test]
+fn withf() {
+    let mut foo = MockFoo::new();
+    foo.expect_foo()
+        .withf(|a| a == "xxx")
+        .return_const(());
+
+    foo.foo("xxx");
+}


### PR DESCRIPTION
This fixes using `predicate::{always, never}` with `?Sized` types.
    
Fixes #78
