### PR TITLE
mock generic methods returning non-static values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased] - ReleaseDate
 ### Added
+
+- Added the ability to mock generic methods whose return values' lifetimes are
+  chosen by the caller.  Especially useful with `std::future::Future`
+  ([#86](https://github.com/asomers/mockall/pull/86))
+
 ### Changed
 ### Fixed
 

--- a/mockall/src/lib.rs
+++ b/mockall/src/lib.rs
@@ -1243,7 +1243,7 @@ pub trait ReturnDefault<O> {
 
 #[derive(Default)]
 #[doc(hidden)]
-pub struct DefaultReturner<O: 'static>(PhantomData<O>);
+pub struct DefaultReturner<O>(PhantomData<O>);
 
 ::cfg_if::cfg_if! {
     if #[cfg(feature = "nightly")] {

--- a/mockall/tests/mock_generic_method_returning_nonstatic.rs
+++ b/mockall/tests/mock_generic_method_returning_nonstatic.rs
@@ -1,0 +1,44 @@
+// vim: tw=80
+//! A generic method whose return value's lifetime is a generic parameter is a
+//! special case.  Mockall can only mock such methods if the expectation is
+//! 'static.
+//! https://github.com/asomers/mockall/issues/76
+
+use mockall::*;
+
+#[derive(Clone)]
+struct X<'a>(&'a u32);
+
+mock! {
+    Thing {
+        fn foo<'a>(&self) -> X<'a>;
+        // XXX static methods don't work yet.
+        // fn bar<'a>() -> X<'a>;
+    }
+}
+
+#[test]
+fn return_static() {
+    const D: u32 = 42;
+    let x = X(&D);
+    let mut thing = MockThing::new();
+    thing.expect_foo()
+        .return_const(x);
+
+    assert_eq!(42u32, *thing.foo().0);
+}
+
+// It isn't possible to safely set an expectation for a non-'static return value
+// (because the mock object doesn't have any lifetime parameters itself), but
+// unsafely setting such an expectation is a common use case.
+#[test]
+fn return_nonstatic() {
+    let d = 42u32;
+    let x = X(&d);
+    let xstatic: X<'static> = unsafe{ std::mem::transmute(x) };
+    let mut thing = MockThing::new();
+    thing.expect_foo()
+        .returning(move || xstatic.clone());
+
+    assert_eq!(42u32, *thing.foo().0);
+}

--- a/mockall_derive/src/automock.rs
+++ b/mockall_derive/src/automock.rs
@@ -409,13 +409,15 @@ fn mock_function(modname: &Ident, vis: &Visibility, sig: &Signature)
     let meth_vis = expectation_visibility(&vis, 1);
     let context_ident = format_ident!("{}_context", &ident);
     let expect_vis = expectation_visibility(&vis, 2);
+    let (_, tg, _) = generics.split_for_impl();
+    let expect_obj = parse2(quote!(Expectations #tg)).unwrap();
     let mut g = generics.clone();
     let lt = Lifetime::new("'guard", Span::call_site());
     let ltd = LifetimeDef::new(lt);
     g.params.push(GenericParam::Lifetime(ltd.clone()));
 
     let mut out = TokenStream::new();
-    Expectation::new(&TokenStream::new(), &inputs, None, generics,
+    Expectation::new(&TokenStream::new(), &inputs, &expect_obj, None, generics,
         &ident, &mod_ident, None, &sig.output, &expect_vis, 1)
         .to_tokens(&mut out);
     let no_match_msg = format!("{}::{}: No matching expectation found",

--- a/mockall_derive/src/expectation.rs
+++ b/mockall_derive/src/expectation.rs
@@ -1040,13 +1040,10 @@ impl<'a> StaticExpectation<'a> {
         let ltdef = LifetimeDef::new(
             Lifetime::new("'__mockall_lt", Span::call_site())
         );
-        meth_generics.params.push(GenericParam::Lifetime(ltdef));
+        meth_generics.params.push(GenericParam::Lifetime(ltdef.clone()));
         let (meth_ig, _meth_tg, meth_wc) = meth_generics.split_for_impl();
 
         let mut e_generics = self.common.egenerics.clone();
-        let ltdef = LifetimeDef::new(
-            Lifetime::new("'__mockall_lt", Span::call_site())
-        );
         e_generics.params.push(GenericParam::Lifetime(ltdef));
         let (e_ig, e_tg, e_wc) = e_generics.split_for_impl();
 

--- a/mockall_derive/src/expectation.rs
+++ b/mockall_derive/src/expectation.rs
@@ -1260,7 +1260,7 @@ impl<'a> StaticExpectation<'a> {
                         ::std::sync::Mutex::new(GenericExpectations::new());
                 }
                 /// Like an
-                /// [`&GenericExpectation`](struct.GenericExpectation.html) but
+                /// [`&Expectation`](struct.Expectation.html) but
                 /// protected by a Mutex guard.  Useful for mocking static
                 /// methods.  Forwards accesses to an `Expectation` object.
                 #v struct ExpectationGuard #e_ig #e_wc{

--- a/mockall_derive/src/mock.rs
+++ b/mockall_derive/src/mock.rs
@@ -389,6 +389,7 @@ fn gen_struct<T>(mock_ident: &syn::Ident,
         }
 
         Expectation::new(&attrs, &meth_types.expectation_inputs,
+                         &meth_types.expect_obj,
                          Some(&generics), &meth_types.expectation_generics,
                          meth_ident, meth_ident, Some(&mock_ident), output,
                          &expect_vis, 2).to_tokens(&mut mod_body);

--- a/mockall_derive/src/mock.rs
+++ b/mockall_derive/src/mock.rs
@@ -258,7 +258,7 @@ fn gen_mock_method(mock_struct_name: &syn::Ident,
     } else {
         &meth_types.expectation_generics
     }.clone();
-    let (tbf_tg, _) = split_lifetimes(tbf_g);
+    let (tbf_tg, _, _) = split_lifetimes(tbf_g, &inputs, &sig.output);
     let (_, tg, _) = tbf_tg.split_for_impl();
     let call_turbofish = tg.as_turbofish();
     let no_match_msg = format!("{}::{}: No matching expectation found",


### PR DESCRIPTION
mock generic methods returning non-static values

It's now possible to mock generic methods whose return values' lifetimes are
chosen by the caller.  This is especially useful for methods that return
std::future::Future.

There are presently two restrictions:
1) static methods and bare functions of this type are not supported
2) The expectations' return values must be 'static.  That can often be
   worked-around via an unsafe lifetime transmute.

Hopefully both of those restrictions will be lifted in time.

Fixes #76