### PR TITLE
Implement `with_st` to match non-`Send` arguments.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased] - ReleaseDate
 ### Added
+
+- Added the ability to match non-`Send` arguments with `withf_st`
+  ([#93](https://github.com/asomers/mockall/pull/93))
+
 ### Changed
 ### Fixed
 ### Removed

--- a/mockall/src/lib.rs
+++ b/mockall/src/lib.rs
@@ -150,7 +150,8 @@
 //! [`returning_st`](https://docs.rs/mockall_examples/latest/mockall_examples/__mock_Foo_Foo/foo/struct.Expectation.html#method.returning_st)
 //! or
 //! [`return_once_st`](https://docs.rs/mockall_examples/latest/mockall_examples/__mock_Foo_Foo/foo/struct.Expectation.html#method.return_once_st)
-//! methods.
+//! methods. If you need to match arguments that are not `Send`, you can use the
+//! [`withf_st`](https://docs.rs/mockall_examples/latest/mockall_examples/__mock_Foo_Foo/foo/struct.Expectation.html#method.withf_st)
 //! These take a non-`Send` object and add runtime access checks.  The wrapped
 //! object will be `Send`, but accessing it from multiple threads will cause a
 //! runtime panic.
@@ -165,10 +166,12 @@
 //!
 //! # fn main() {
 //! let mut mock = MockFoo::new();
+//! let x = Rc::new(5);
+//! let argument = x.clone();
 //! mock.expect_foo()
-//!     .withf(|x| **x == 5)
+//!     .withf_st(move |x| *x == argument)
 //!     .returning_st(move |_| Rc::new(42u32));
-//! assert_eq!(42, *mock.foo(Rc::new(5)));
+//! assert_eq!(42, *mock.foo(x));
 //! # }
 //! ```
 //!

--- a/mockall/tests/automock_nonsend.rs
+++ b/mockall/tests/automock_nonsend.rs
@@ -19,3 +19,14 @@ fn returning_st() {
     let x = Rc::new(42u32);
     assert_eq!(43, *mock.foo(x).as_ref());
 }
+
+#[test]
+fn withf_st() {
+    let mut mock = MockFoo::new();
+    let x = Rc::new(42u32);
+    let argument = x.clone();
+    mock.expect_foo()
+        .withf_st(move |x| *x == argument)
+        .returning_st(|_| Rc::new(43u32));
+    assert_eq!(43, *mock.foo(x).as_ref());
+}

--- a/mockall/tests/automock_nonsend.rs
+++ b/mockall/tests/automock_nonsend.rs
@@ -8,6 +8,9 @@ use std::rc::Rc;
 trait Foo {
     // Rc is not Send
     fn foo(&self, x: Rc<u32>) -> Rc<u32>;
+
+    // Rc is not Send
+    fn bar(x: Rc<u32>) -> Rc<u32>;
 }
 
 #[test]
@@ -21,6 +24,16 @@ fn returning_st() {
 }
 
 #[test]
+fn returning_st_static() {
+    let mock = MockFoo::bar_context();
+    let y = Rc::new(43u32);
+    mock.expect()
+        .returning_st(move |_| y.clone());
+    let x = Rc::new(42u32);
+    assert_eq!(43, *MockFoo::bar(x).as_ref());
+}
+
+#[test]
 fn withf_st() {
     let mut mock = MockFoo::new();
     let x = Rc::new(42u32);
@@ -29,4 +42,15 @@ fn withf_st() {
         .withf_st(move |x| *x == argument)
         .returning_st(|_| Rc::new(43u32));
     assert_eq!(43, *mock.foo(x).as_ref());
+}
+
+#[test]
+fn withf_st_static() {
+    let mock = MockFoo::bar_context();
+    let x = Rc::new(42u32);
+    let argument = x.clone();
+    mock.expect()
+        .withf_st(move |x| *x == argument)
+        .returning_st(|_| Rc::new(43u32));
+    assert_eq!(43, *MockFoo::bar(x).as_ref());
 }

--- a/mockall_derive/src/expectation.rs
+++ b/mockall_derive/src/expectation.rs
@@ -194,7 +194,7 @@ impl<'a> Common<'a> {
             }
 
             /// Single-threaded version of [`withf`](#method.withf).
-            /// Can be used when the argument or return type isn't `Send`.
+            /// Can be used when the argument type isn't `Send`.
             #v fn withf_st<MockallF>(&mut self, __mockall_f: MockallF) -> &mut Self
                 where MockallF: #hrtb Fn(#(&#predty, )*)
                                 -> bool + 'static

--- a/mockall_derive/src/expectation.rs
+++ b/mockall_derive/src/expectation.rs
@@ -192,6 +192,16 @@ impl<'a> Common<'a> {
                 self.common.withf(__mockall_f);
                 self
             }
+
+            /// Single-threaded version of [`withf`](#method.withf).
+            /// Can be used when the argument or return type isn't `Send`.
+            #v fn withf_st<MockallF>(&mut self, __mockall_f: MockallF) -> &mut Self
+                where MockallF: #hrtb Fn(#(&#predty, )*)
+                                -> bool + 'static
+            {
+                self.common.withf_st(__mockall_f);
+                self
+            }
         )
     }
 
@@ -391,6 +401,8 @@ impl<'a> Expectation<'a> {
             enum Matcher #ig #wc {
                 Always,
                 Func(Box<dyn #hrtb Fn(#refpredty) -> bool + Send>),
+                // Version of Matcher::Func for closures that aren't Send
+                FuncST(::mockall::Fragile<Box<dyn #hrtb Fn(#refpredty) -> bool>>),
                 Pred(Box<(#preds)>),
                 // Prevent "unused type parameter" errors
                 // Surprisingly, PhantomData<Fn(generics)> is Send even if
@@ -404,6 +416,8 @@ impl<'a> Expectation<'a> {
                         Matcher::Always => true,
                         Matcher::Func(__mockall_f) =>
                             __mockall_f(#(#argnames, )*),
+                        Matcher::FuncST(__mockall_f) =>
+                            (__mockall_f.get())(#(#argnames, )*),
                         Matcher::Pred(__mockall_pred) =>
                             [#pred_matches]
                             .iter()
@@ -427,6 +441,7 @@ impl<'a> Expectation<'a> {
                     match self {
                         Matcher::Always => write!(__mockall_fmt, "<anything>"),
                         Matcher::Func(_) => write!(__mockall_fmt, "<function>"),
+                        Matcher::FuncST(_) => write!(__mockall_fmt, "<single threaded function>"),
                         Matcher::Pred(__mockall_p) => {
                             write!(__mockall_fmt, #braces,
                                 #(__mockall_p.#indices,)*)
@@ -519,6 +534,15 @@ impl<'a> Expectation<'a> {
                     let mut __mockall_guard = self.matcher.lock().unwrap();
                     mem::replace(__mockall_guard.deref_mut(),
                                  Matcher::Func(Box::new(__mockall_f)));
+                }
+
+                fn withf_st<MockallF>(&mut self, __mockall_f: MockallF)
+                    where MockallF: #hrtb Fn(#refpredty)
+                                    -> bool + 'static
+                {
+                    let mut __mockall_guard = self.matcher.lock().unwrap();
+                    mem::replace(__mockall_guard.deref_mut(),
+                                 Matcher::FuncST(::mockall::Fragile::new(Box::new(__mockall_f))));
                 }
 
                 fn verify_sequence(&self) {
@@ -1267,6 +1291,16 @@ impl<'a> StaticExpectation<'a> {
                     {
                         self.guard.0[self.i].withf(__mockall_f)
                     }
+
+                    /// Just like
+                    /// [`Expectation::withf_st`](struct.Expectation.html#method.withf_st)
+                    #v fn withf_st<MockallF>(&mut self, __mockall_f: MockallF)
+                        -> &mut Expectation #tg
+                        where MockallF: #hrtb Fn(#(&#predty, )*)
+                                        -> bool + 'static
+                    {
+                        self.guard.0[self.i].withf_st(__mockall_f)
+                    }
                 }
                 #context_ts
             )
@@ -1462,6 +1496,21 @@ impl<'a> StaticExpectation<'a> {
                             .unwrap()
                             .0[self.i]
                             .withf(__mockall_f)
+                    }
+
+                    /// Just like
+                    /// [`Expectation::withf_st`](struct.Expectation.html#method.withf_st)
+                    #v fn withf_st<MockallF>(&mut self, __mockall_f: MockallF) -> &mut Expectation #tg
+                        where MockallF: #hrtb Fn(#(&#predty, )*)
+                                        -> bool + 'static
+                    {
+                        self.guard.store.get_mut(
+                                &::mockall::Key::new::<(#(#argty, )*)>()
+                            ).unwrap()
+                            .downcast_mut::<Expectations #tg>()
+                            .unwrap()
+                            .0[self.i]
+                            .withf_st(__mockall_f)
                     }
                 }
                 #context_ts


### PR DESCRIPTION
See #80.