### PR TITLE
Allow doc comments in mock! macro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased] - ReleaseDate
 ### Added
 
+- `mock!` now allows doc comments in any position
+  ([#102](https://github.com/asomers/mockall/pull/102))
+
 - Added the ability to match non-`Send` arguments with `withf_st`
   ([#93](https://github.com/asomers/mockall/pull/93))
 

--- a/mockall/tests/mock_docs.rs
+++ b/mockall/tests/mock_docs.rs
@@ -1,4 +1,6 @@
 // vim: tw=80
+#![deny(missing_docs)]
+
 use mockall::*;
 
 // mock! should allow doc comments in all reasonable positions.  This test
@@ -15,10 +17,9 @@ mock!{
         /// Method docs
         fn foo(&self);
     }
+    /// Trait docs
     trait Tr {
         /// Trait method docs
         fn bar(&self);
     }
 }
-
-

--- a/mockall/tests/mock_docs.rs
+++ b/mockall/tests/mock_docs.rs
@@ -1,0 +1,24 @@
+// vim: tw=80
+use mockall::*;
+
+// mock! should allow doc comments in all reasonable positions.  This test
+// ensures that the code will compile.  mockall_derive has a unit test to ensure
+// that the doc comments are correctly placed.
+
+trait Tr {
+    fn bar(&self);
+}
+
+mock!{
+    /// Struct docs
+    pub Foo {
+        /// Method docs
+        fn foo(&self);
+    }
+    trait Tr {
+        /// Trait method docs
+        fn bar(&self);
+    }
+}
+
+

--- a/mockall_derive/src/automock.rs
+++ b/mockall_derive/src/automock.rs
@@ -529,6 +529,7 @@ fn mock_impl(item_impl: ItemImpl) -> TokenStream {
         (methods, Vec::new())
     };
     let mock = Mock {
+        attrs: item_impl.attrs.clone(),
         vis,
         name,
         generics: item_impl.generics.clone(),
@@ -608,6 +609,7 @@ fn mock_native_function(modname: &Ident, f: &ItemFn) -> TokenStream {
 fn mock_trait(attrs: Attrs, item: ItemTrait) -> TokenStream {
     let trait_ = attrs.substitute_trait(&item);
     let mock = Mock {
+        attrs: item.attrs.clone(),
         vis: item.vis.clone(),
         name: item.ident.clone(),
         generics: item.generics.clone(),


### PR DESCRIPTION
Previously, the build would fail if the mock struct line contained a doc
comment.  Now, the build will pass, and doc comments on the struct and
methods will be propagated to the generated code.

Fixes #100