### PR TITLE
Update Fragile to 1.0

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -2,7 +2,7 @@ test_task:
   name: cargo test 
   matrix:
     - container:
-       image: rust:1.35.0
+       image: rust:1.36.0
     - container:
        image: rust:latest
     - container:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed the docs for `mockall_examples`
   ([#103](https://github.com/asomers/mockall/pull/103))
 
+- Fixed the build with nightly compilers 2020-03-11 and later
+  ([#108](https://github.com/asomers/mockall/pull/108))
+
 ### Removed
 
 ## [0.6.0] - 5 December 2019

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed the docs for `mockall_examples`
   ([#103](https://github.com/asomers/mockall/pull/103))
 
-- Fixed the build with nightly compilers 2020-03-11 and later
+- Fixed the build with nightly compilers 2020-03-11 and later.  This also
+  raises the MSRV to 1.36.0.
   ([#108](https://github.com/asomers/mockall/pull/108))
 
 ### Removed

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ See the [API docs](https://docs.rs/mockall) for more information.
 
 # Minimum Supported Rust Version (MSRV)
 
-Mockall is supported on Rust 1.35.0 and higher.  Mockall's MSRV will not be
+Mockall is supported on Rust 1.36.0 and higher.  Mockall's MSRV will not be
 changed in the future without bumping the major or minor version.
 
 # License

--- a/mockall/Cargo.toml
+++ b/mockall/Cargo.toml
@@ -23,7 +23,7 @@ nightly = ["mockall_derive/nightly_derive"]
 [dependencies]
 cfg-if = "0.1.6"
 downcast = "0.10"
-fragile = "0.3"
+fragile = "1.0"
 lazy_static = "1.1"
 predicates = "1.0.2"
 predicates-tree = "1.0"


### PR DESCRIPTION
This fixes runtime errors with the latest nightly compiler, 2020-03-11
or later, which are stricter about uninitialized data.