### PR TITLE
Allow mocking non-'static structs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Added the ability to match non-`Send` arguments with `withf_st`
   ([#93](https://github.com/asomers/mockall/pull/93))
 
+- Added the ability to mock non-`'static` structs (but not their constructor
+  methods)
+  ([#114](https://github.com/asomers/mockall/pull/114))
+
 ### Changed
 ### Fixed
 

--- a/mockall/tests/automock_nonstatic_struct.rs
+++ b/mockall/tests/automock_nonstatic_struct.rs
@@ -1,0 +1,50 @@
+// vim: tw=80
+//! Mock a struct with a lifetime parameter
+
+use mockall::*;
+
+pub struct NonStaticStruct<'nss> {
+    _x: &'nss i32
+}
+
+#[automock]
+impl<'nss> NonStaticStruct<'nss> {
+    pub fn foo(&self) -> i64 {
+        42
+    }
+    pub fn bar() -> i64{
+        42
+    }
+    // XXX Constructors aren't yet supported for non-static Structs
+    //pub fn new(x: &'nss i32) -> Self {
+        //NonStaticStruct{x}
+    //}
+}
+
+#[test]
+fn normal_method() {
+    // This function serves to define a named lifetime
+    fn has_lt<'a>(_x: &'a i8) {
+        let mut mock = MockNonStaticStruct::<'a>::default();
+        mock.expect_foo()
+            .returning(|| 5);
+        assert_eq!(5, mock.foo());
+    }
+
+    let x = 42i8;
+    has_lt(&x);
+}
+
+#[test]
+fn static_method() {
+    // This function serves to define a named lifetime
+    fn has_lt<'a>(_x: &'a i8) {
+        let ctx = MockNonStaticStruct::bar_context();
+        ctx.expect()
+            .returning(|| 5);
+        assert_eq!(5, MockNonStaticStruct::bar());
+    }
+
+    let x = 42i8;
+    has_lt(&x);
+}

--- a/mockall_derive/src/mock.rs
+++ b/mockall_derive/src/mock.rs
@@ -279,7 +279,8 @@ fn gen_mock_method(mock_struct_name: &syn::Ident,
     // Then the expectation method
     if meth_types.is_static {
         let context_ident = format_ident!("{}_context", ident);
-        let (_, ctx_tg, _) = generics.split_for_impl();
+        let context_generics = strip_generics_lifetimes(generics);
+        let (_, ctx_tg, _) = context_generics.split_for_impl();
         quote!(#attrs_nodocs
                /// Create a [`Context`](#mod_ident/ident/struct.Context.html)
                /// for mocking the `ident` method


### PR DESCRIPTION
Constructor methods are not yet supported.

Fixes #4

The gory details:
* Generics of mock structs should not include lifetimes
* deselfify before split lifetimes
* Include rlifetimes in some impl blocks
* Include some missing <> in an intermediate Generics object
* Fix deselfify with lifetimes
* Handle apparently unused lifetimes in  split_lifetimes
* Fix determination of whether a method is generic in method_types.  There was
  some leftover logic from back when all methods of generic structs were
  treated as generic methods.
* Remove lifetimes from Context objects