### PR TITLE
Fix mem::replace warning

### DIFF
--- a/mockall_derive/src/lib.rs
+++ b/mockall_derive/src/lib.rs
@@ -77,7 +77,7 @@ cfg_if! {
 
 // If there are any closures in the argument list, turn them into boxed
 // functions
-fn declosurefy(gen: &Generics, args: &Punctuated<FnArg, Token![,]>) -> 
+fn declosurefy(gen: &Generics, args: &Punctuated<FnArg, Token![,]>) ->
     (Generics, Punctuated<FnArg, Token![,]>, Punctuated<TokenStream, Token![,]>)
 {
     let mut hm = HashMap::new();
@@ -516,7 +516,7 @@ fn supersuperfy(original: &Type, levels: i32) -> Type {
             Type::BareFn(bfn) => {
                 if let ReturnType::Type(_, ref mut bt) = bfn.output {
                     let new_bt = Box::new(supersuperfy(bt.as_ref(), levels));
-                    mem::replace(bt, new_bt);
+                    let _ = mem::replace(bt, new_bt);
                 }
                 for input in bfn.inputs.iter_mut() {
                     input.ty = supersuperfy(&input.ty, levels);

--- a/mockall_derive/src/lib.rs
+++ b/mockall_derive/src/lib.rs
@@ -13,8 +13,7 @@ use proc_macro2::{Span, TokenStream};
 use quote::{format_ident, quote};
 use std::{
     collections::{HashMap, HashSet},
-    iter::FromIterator,
-    mem
+    iter::FromIterator
 };
 use syn::{
     *,
@@ -515,8 +514,7 @@ fn supersuperfy(original: &Type, levels: i32) -> Type {
             },
             Type::BareFn(bfn) => {
                 if let ReturnType::Type(_, ref mut bt) = bfn.output {
-                    let new_bt = Box::new(supersuperfy(bt.as_ref(), levels));
-                    let _ = mem::replace(bt, new_bt);
+                    *bt = Box::new(supersuperfy(bt.as_ref(), levels));
                 }
                 for input in bfn.inputs.iter_mut() {
                     input.ty = supersuperfy(&input.ty, levels);


### PR DESCRIPTION
This PR fixes the following warning caused by not using the returned
value from `mem::replace`.

```
warning: unused return value of `std::mem::replace` that must be used
--> mockall_derive/src/lib.rs:519:21
    |
519 |                     mem::replace(bt, new_bt);
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `#[warn(unused_must_use)]` on by default
    = note: if you don't need the old value, you can
    just assign the new value directly

warning: 1 warning emitted
```