### PR TITLE
Fix mocking functions with attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,15 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## [Unreleased] -ReleaseDate
+## [Unreleased] - ReleaseDate
 ### Added
 ### Changed
 ### Fixed
+
+- Fixed handling function attributes.  They already worked on methods, but not
+  foreign functions or module functions.
+  ([#129](https://github.com/asomers/mockall/pull/129))
+
 ### Removed
 
 ## [0.7.1] - 3 May 2020

--- a/mockall/tests/automock_attrs.rs
+++ b/mockall/tests/automock_attrs.rs
@@ -1,7 +1,31 @@
 // vim: tw=80
 //! Attributes are applied to the mock object, too.
+#![allow(unused)]
+#![cfg_attr(feature = "nightly", feature(proc_macro_hygiene))]
+
+use cfg_if::cfg_if;
 
 use mockall::*;
+
+cfg_if! {
+    if #[cfg(feature = "nightly")] {
+        #[automock]
+        mod m {
+            #[cfg(target_os = "multics")]
+            pub fn bloob(x: DoesNotExist) -> i64 {unimplemented!()}
+            #[cfg(not(target_os = "multics"))]
+            pub fn blarg(x: i32) -> i64 {unimplemented!()}
+        }
+
+        #[test]
+        fn returning() {
+            let ctx = mock_m::blarg_context();
+            ctx.expect()
+                .returning(|x| i64::from(x) + 1);
+            assert_eq!(5, mock_m::blarg(4));
+        }
+    }
+}
 
 pub struct A{}
 #[automock]
@@ -12,10 +36,27 @@ impl A {
     #[cfg(not(target_os = "multics"))] pub fn bar(&self, _x: i32) -> i32 {0}
 }
 
+#[automock(mod mock_ffi;)]
+extern "C" {
+    // mock_ffi::baz should not be defined
+    #[cfg(target_os = "multics")]
+    fn baz(x: DoesNotExist) -> i64;
+    // mock_ffi::bean should be defined
+    #[cfg(not(target_os = "multics"))]
+    fn bean(x: u32) -> i64;
+}
+
 #[test]
-fn returning() {
+fn method() {
     let mut mock = MockA::new();
     mock.expect_bar()
         .returning(|x| x);
     assert_eq!(4, mock.bar(4));
+}
+
+#[test]
+fn foreign() {
+    let ctx = mock_ffi::bean_context();
+    ctx.expect().returning(i64::from);
+    assert_eq!(42, unsafe{mock_ffi::bean(42)});
 }

--- a/mockall_derive/src/lib.rs
+++ b/mockall_derive/src/lib.rs
@@ -10,7 +10,7 @@ extern crate proc_macro;
 
 use cfg_if::cfg_if;
 use proc_macro2::{Span, TokenStream};
-use quote::{format_ident, quote};
+use quote::{ToTokens, format_ident, quote};
 use std::{
     collections::{HashMap, HashSet},
     iter::FromIterator
@@ -464,6 +464,17 @@ fn find_lifetimes(ty: &Type) -> HashSet<Lifetime> {
         }
 
     }
+}
+
+fn format_attrs(attrs: &[syn::Attribute], include_docs: bool) -> TokenStream {
+    let mut out = TokenStream::new();
+    for attr in attrs {
+        let is_doc = attr.path.get_ident().map(|i| i == "doc").unwrap_or(false);
+        if !is_doc || include_docs {
+            attr.to_tokens(&mut out);
+        }
+    }
+    out
 }
 
 /// Return a new Generics object based on the given one but with lifetimes


### PR DESCRIPTION
Fix mocking functions with attributes
    
When mocking methods, we forward all non-doc attributes to the mock method.  This commit ensures that we do the same for foreign functions and module functions.  It allows, for example:
    
```rust
#[automock]
extern "C" {
    #[cfg(target_os = "linux")]
    fn linux_func();
    #[cfg(target_os = "freebsd")]
    fn freebsd_func();
}
```
