### PR TITLE
Fix some visibility issues with mocking modules and foreign functions:

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Fix the formatting of generated doc comments for context methods
   ([#132](https://github.com/asomers/mockall/pull/132))
 
+- Fixed some visibility issues in the generated mocks for modules and extern
+  functions.
+  ([#133](https://github.com/asomers/mockall/pull/133))
+
 ### Removed
 
 ## [0.7.1] - 3 May 2020

--- a/mockall/tests/automock_foreign_nonpub.rs
+++ b/mockall/tests/automock_foreign_nonpub.rs
@@ -1,0 +1,57 @@
+// vim: tw=80
+//! "extern" blocks aren't modules, and shouldn't introduce another layer of
+//! "super"s.
+//!
+//! The tests really just check that the visibility of the functions and
+//! expectations functions is correct.
+#[allow(unused)]
+mod outer {
+    struct SuperT();
+
+    pub mod inner {
+        use mockall::automock;
+
+        #[derive(Debug)]
+        pub(crate) struct PubCrateT();
+        #[derive(Debug)]
+        struct PrivT();
+
+        #[automock(mod mock_ffi;)]
+        extern "Rust" {
+            pub(crate) fn foo(x: PubCrateT) -> PubCrateT;
+            fn bar(x: PrivT) -> PrivT;
+            pub(in super) fn baz(x: super::SuperT) -> super::SuperT;
+            pub(in crate::outer) fn bang(x: crate::outer::SuperT)
+                -> crate::outer::SuperT;
+        }
+
+        #[test]
+        fn test_bar() {
+            let ctx = mock_ffi::bar_context();
+            ctx.expect().returning(|_| PrivT());
+            unsafe{mock_ffi::bar(PrivT())};
+        }
+    
+
+        #[test]
+        fn test_baz() {
+            let ctx = mock_ffi::baz_context();
+            ctx.expect().returning(|_| super::SuperT());
+            unsafe{mock_ffi::baz(super::SuperT())};
+        }
+    }
+
+    #[test]
+    fn test_bang() {
+        let ctx = inner::mock_ffi::bang_context();
+        ctx.expect().returning(|_| SuperT());
+        unsafe{inner::mock_ffi::bang(SuperT())};
+    }
+}
+
+#[test]
+fn foo() {
+    let ctx = outer::inner::mock_ffi::foo_context();
+    ctx.expect().returning(|_| outer::inner::PubCrateT());
+    unsafe{outer::inner::mock_ffi::foo(outer::inner::PubCrateT())};
+}

--- a/mockall/tests/automock_module_nonpub.rs
+++ b/mockall/tests/automock_module_nonpub.rs
@@ -22,12 +22,20 @@ cfg_if::cfg_if! {
                 mod m {
                     use super::*;
 
-                    fn foo(x: PubCrateT) -> PubCrateT { unimplemented!() }
-                    fn bar(x: PrivT) -> PrivT { unimplemented!() }
-                    fn baz(x: super::super::SuperT) -> super::super::SuperT {
+                    pub(crate) fn foo(x: PubCrateT) -> PubCrateT {
                         unimplemented!()
                     }
-                    fn bang(x: crate::outer::SuperT) -> crate::outer::SuperT {
+                    pub(super) fn bar(x: PrivT) -> PrivT {
+                        unimplemented!()
+                    }
+                    pub(in super::super) fn baz(x: super::super::SuperT)
+                        -> super::super::SuperT
+                    {
+                        unimplemented!()
+                    }
+                    pub(in crate::outer) fn bang(x: crate::outer::SuperT)
+                        -> crate::outer::SuperT
+                    {
                         unimplemented!()
                     }
                 }

--- a/mockall_derive/src/lib.rs
+++ b/mockall_derive/src/lib.rs
@@ -773,10 +773,13 @@ fn split_lifetimes(
 /// # Arguments
 /// - `vis`:    Original visibility of the item
 /// - `levels`: How many modules will the mock item be nested in?
-fn expectation_visibility(vis: &Visibility, levels: u32)
+fn expectation_visibility(vis: &Visibility, levels: i32)
     -> Visibility
 {
-    debug_assert!(levels > 0);
+    if levels == 0 {
+        return vis.clone();
+    }
+
     let in_token = Token![in](vis.span());
     let super_token = Token![super](vis.span());
     match vis {


### PR DESCRIPTION
* When mocking foreign functions, the 'foreign "<ABI>"' block is not a
  module, and should not introduce an extra layer of visibility
  modifications.

* The visibility of the Expectation must always match the levels
  argument of Expectation::new().

* When mocking modules, the argument and return types of mocked
  functions must be superfied by one level.  Otherwise code like this
  wouldn't compile:
  ```rust
  struct SuperT;

  #[automock]
  pub mod m {
      fn foo(x: super::SuperT) -> super::SuperT;
  }
  ```