### PR TITLE
Fix mocking methods with types including a `super::` component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   functions.
   ([#133](https://github.com/asomers/mockall/pull/133))
 
+- Fixed mocking methods with complicated types including a `super::` component.
+  ([#137](https://github.com/asomers/mockall/pull/137))
+
 ### Removed
 
 ## [0.7.1] - 3 May 2020


### PR DESCRIPTION
Examples of methods that would be mocked incorrectly include:
```
fn foo(&self, x: [super::T]);
fn bar(&self) -> (super::T, i32);
```

This is a bug that was introduced by
697d341d7cd622e8ba4bf15cb15f6cacbb76220a.  That revision correctly
handled `super` when it appeared in `Path` and `TraitObject` types, but
not more complicated types.