### PR TITLE
Reduce duplication in merged Generics

### DIFF
--- a/mockall_derive/src/lib.rs
+++ b/mockall_derive/src/lib.rs
@@ -636,7 +636,9 @@ fn merge_generics(x: &Generics, y: &Generics) -> Generics {
                             ot.default = yt.default.clone();
                         }
                         // XXX this might result in duplicate bounds
-                        ot.bounds.extend(yt.bounds.iter().cloned());
+                        if ot.bounds != yt.bounds {
+                            ot.bounds.extend(yt.bounds.iter().cloned());
+                        }
                     }
                     continue 'outer_param;
                 }
@@ -667,7 +669,9 @@ fn merge_generics(x: &Generics, y: &Generics) -> Generics {
                                         ybl.lifetimes.iter().cloned()),
                             };
                             // XXX: might result in duplicate bounds
-                            ot.bounds.extend(yt.bounds.iter().cloned())
+                            if ot.bounds != yt.bounds {
+                                ot.bounds.extend(yt.bounds.iter().cloned())
+                            }
                         }
                         continue 'outer_wc;
                     }
@@ -938,8 +942,11 @@ pub fn automock(attrs: proc_macro::TokenStream, input: proc_macro::TokenStream)
 mod t {
     use super::*;
 
+mod merge_generics {
+    use super::*;
+
     #[test]
-    fn merge_generics() {
+    fn both() {
         let mut g1: Generics = parse2(quote!(<T: 'static, V: Copy> )).unwrap();
         let wc1: WhereClause = parse2(quote!(where T: Default)).unwrap();
         g1.where_clause = Some(wc1);
@@ -961,6 +968,51 @@ mod t {
         assert_eq!(quote!(#ge #wce).to_string(),
                    quote!(#gm #gm_wc).to_string());
     }
+
+    #[test]
+    fn eq() {
+        let mut g1: Generics = parse2(quote!(<T: 'static, V: Copy> )).unwrap();
+        let wc1: WhereClause = parse2(quote!(where T: Default)).unwrap();
+        g1.where_clause = Some(wc1.clone());
+
+        let g2 = g1.clone();
+
+        let gm = super::merge_generics(&g1, &g2);
+        let gm_wc = &gm.where_clause;
+
+        assert_eq!(quote!(#g1 #wc1).to_string(),
+                   quote!(#gm #gm_wc).to_string());
+    }
+
+    #[test]
+    fn lhs_only() {
+        let mut g1: Generics = parse2(quote!(<T: 'static, V: Copy> )).unwrap();
+        let wc1: WhereClause = parse2(quote!(where T: Default)).unwrap();
+        g1.where_clause = Some(wc1.clone());
+
+        let g2 = Generics::default();
+
+        let gm = super::merge_generics(&g1, &g2);
+        let gm_wc = &gm.where_clause;
+
+        assert_eq!(quote!(#g1 #wc1).to_string(),
+                   quote!(#gm #gm_wc).to_string());
+    }
+
+    #[test]
+    fn rhs_only() {
+        let g1 = Generics::default();
+        let mut g2: Generics = parse2(quote!(<Q: Send, V: Clone>)).unwrap();
+        let wc2: WhereClause = parse2(quote!(where T: Sync, Q: Debug)).unwrap();
+        g2.where_clause = Some(wc2.clone());
+
+        let gm = super::merge_generics(&g1, &g2);
+        let gm_wc = &gm.where_clause;
+
+        assert_eq!(quote!(#g2 #wc2).to_string(),
+                   quote!(#gm #gm_wc).to_string());
+    }
+}
 
 // Tests for the method_types function.  But there are no assertions for the
 // call_exprs field, because TokenStream doesn't implement Eq or anything close

--- a/mockall_derive/src/mock.rs
+++ b/mockall_derive/src/mock.rs
@@ -380,14 +380,6 @@ fn gen_struct<T>(attrs: &[syn::Attribute],
         let output = &meth_types.output;
 
         let expect_vis = expectation_visibility(&meth.borrow().vis, 2);
-        let mut macro_g = TokenStream::new();
-        let merged_g = merge_generics(&generics, &meth_types.expectation_generics);
-        if ! merged_g.params.is_empty() {
-            merged_g.split_for_impl().1.to_tokens(&mut macro_g)
-        } else {
-            // expectation! requires the <> even if it's empty
-            quote!(<>).to_tokens(&mut macro_g);
-        }
 
         Expectation::new(&attrs, &meth_types.expectation_inputs,
                          Some(&generics), &meth_types.expectation_generics,


### PR DESCRIPTION
    Previously, Mockall would often duplicate the bounds in Generics fields,
    both in the parameter list and in the where clause.  Counterintuitively,
    it even did that when one of the two Generics being merged was empty.
    
    This simple change fixes most duplication, but it's still possible where
    the two Generics have partially overlapping bounds.
    
    AFAIK this bug never prevented any mocks from compiling.  Rust dutifully
    accepts duplicate Generics bounds.
