### PR TITLE
Fix return_const on mocked generic static methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed mocking methods with complicated types including a `super::` component.
   ([#137](https://github.com/asomers/mockall/pull/137))
 
+- Mocked generic static methods can now use `return_const`.  This capability
+  was omitted as an oversight from PR #47.
+  ([#141](https://github.com/asomers/mockall/pull/141))
+
 ### Removed
 
 ## [0.7.1] - 3 May 2020

--- a/mockall/tests/automock_generic_static_method.rs
+++ b/mockall/tests/automock_generic_static_method.rs
@@ -2,6 +2,11 @@
 //! generic static methods with generic arguments
 
 use mockall::*;
+use std::sync::Mutex;
+
+lazy_static! {
+    static ref A_MTX: Mutex<()> = Mutex::new(());
+}
 
 #[automock]
 trait A {
@@ -10,8 +15,20 @@ trait A {
 
 #[test]
 fn returning() {
+    let _m = A_MTX.lock().unwrap();
+
     let ctx = MockA::bar_context();
     ctx.expect::<i16>()
         .returning(|_| 42);
+    assert_eq!(42, MockA::bar(-1i16));
+}
+
+#[test]
+fn return_const() {
+    let _m = A_MTX.lock().unwrap();
+
+    let ctx = MockA::bar_context();
+    ctx.expect::<i16>()
+        .return_const(42u32);
     assert_eq!(42, MockA::bar(-1i16));
 }

--- a/mockall_derive/src/expectation.rs
+++ b/mockall_derive/src/expectation.rs
@@ -1390,6 +1390,22 @@ impl<'a> StaticExpectation<'a> {
                     }
 
                     /// Just like
+                    /// [`Expectation::return_const`](struct.Expectation.html#method.return_const)
+                    #v fn return_const<MockallOutput>
+                    (&mut self, __mockall_c: MockallOutput)
+                        -> &mut Expectation #tg
+                        where MockallOutput: Clone + Into<#output> + Send + 'static
+                    {
+                        self.guard.store.get_mut(
+                                &::mockall::Key::new::<(#(#argty, )*)>()
+                            ).unwrap()
+                            .downcast_mut::<Expectations #tg>()
+                            .unwrap()
+                            .0[self.i]
+                            .return_const(__mockall_c)
+                    }
+
+                    /// Just like
                     /// [`Expectation::returning`](struct.Expectation.html#method.returning)
                     #v fn returning<MockallF>(&mut self, __mockall_f: MockallF)
                         -> &mut Expectation #tg


### PR DESCRIPTION
This was left out of PR #47 as an oversight.  That PR only fixed
return_const for non-generic static methods.