### PR TITLE
Better error messages with mock!

### DIFF
--- a/mockall_derive/Cargo.toml
+++ b/mockall_derive/Cargo.toml
@@ -25,7 +25,7 @@ nightly_derive = ["proc-macro2/nightly"]
 cfg-if = "0.1.6"
 proc-macro2 = "1.0"
 quote = "1.0"
-syn = { version = "1.0.3", features = ["extra-traits", "full"] }
+syn = { version = "1.0.15", features = ["extra-traits", "full"] }
 
 [dev-dependencies]
 pretty_assertions = "0.5"


### PR DESCRIPTION
When mock! fails due to unsupported items in the struct section, print a
better error message, including the span.

Issue #143