### PR TITLE
Suppress "unused unit" warnings from Clippy in the generated code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   was omitted as an oversight from PR #47.
   ([#141](https://github.com/asomers/mockall/pull/141))
 
+- Suppressed `unused unit` warnings from Clippy in the latest nightly.
+  ([#148](https://github.com/asomers/mockall/pull/148))
+
 ### Removed
 
 ## [0.7.1] - 3 May 2020

--- a/mockall_derive/src/automock.rs
+++ b/mockall_derive/src/automock.rs
@@ -362,6 +362,7 @@ fn mock_foreign(attrs: Attrs, foreign_mod: ItemForeignMod) -> TokenStream {
         pub fn checkpoint() { #cp_body }).to_tokens(&mut body);
     quote!(
         #[allow(missing_docs)]
+        #[allow(clippy::unused_unit)]
         pub mod #modname {
             use super::*;
             #body
@@ -639,6 +640,7 @@ fn mock_module(mod_: ItemMod) -> TokenStream {
     };
     quote!(
         #docstr
+        #[allow(clippy::unused_unit)]
         pub mod #modname { #body })
 }
 

--- a/mockall_derive/src/mock.rs
+++ b/mockall_derive/src/mock.rs
@@ -429,6 +429,7 @@ fn gen_struct<T>(attrs: &[syn::Attribute],
     let (ig, tg, wc) = generics.split_for_impl();
     quote!(
         #[allow(non_snake_case)]
+        #[allow(clippy::unused_unit)]
         #[doc(hidden)]
         pub mod #mod_ident {
             use super::*;


### PR DESCRIPTION
These warnings are new in the latest nightly 1.46.0.

Fixes #142