### PR TITLE
Don't generate as many -> () return types

### DIFF
--- a/mockall_derive/src/mock_item.rs
+++ b/mockall_derive/src/mock_item.rs
@@ -146,9 +146,6 @@ impl ToTokens for MockItemModule {
         };
         quote!(
             #docstr
-            // TODO: remove the allow unused_unit
-            // https://github.com/asomers/mockall/issues/149
-            #[allow(clippy::unused_unit)]
             #vis mod #modname {
                 #body
         }).to_tokens(tokens);

--- a/mockall_derive/src/mock_item_struct.rs
+++ b/mockall_derive/src/mock_item_struct.rs
@@ -267,9 +267,6 @@ impl ToTokens for MockItemStruct {
         let vis = &self.vis;
         quote!(
             #[allow(non_snake_case)]
-            // TODO: remove the allow unused_unit
-            // https://github.com/asomers/mockall/issues/149
-            #[allow(clippy::unused_unit)]
             #[doc(hidden)]
             pub mod #modname {
                 use super::*;
@@ -345,9 +342,6 @@ impl ToTokens for MockItemTraitImpl {
         let priv_mods = self.methods.priv_mods();
         quote!(
             #[allow(non_snake_case)]
-            // TODO: remove the allow unused_unit
-            // https://github.com/asomers/mockall/issues/149
-            #[allow(clippy::unused_unit)]
             #[doc(hidden)]
             pub mod #modname {
                 use super::*;

--- a/mockall_derive/src/mockable_item.rs
+++ b/mockall_derive/src/mockable_item.rs
@@ -91,22 +91,8 @@ impl From<(Attrs, ItemForeignMod)> for MockableModule {
                                 *pt.ty = supersuperfy(&*pt.ty, 1);
                             }
                         }
-                        match &mut sig.output {
-                            ReturnType::Type(_, ty) =>
-                                **ty = supersuperfy(&*ty, 1),
-                            ReturnType::Default => {
-                                // Add an explicit "-> ()" for perfect
-                                // compatibility with 0.7.0.  TODO: remove this
-                                // after merging the 2020_refactor branch
-                                // https://github.com/asomers/mockall/issues/149
-                                let rarrow = Token![->](sig.output.span());
-                                let unit = Type::Tuple(TypeTuple{
-                                    paren_token: token::Paren::default(),
-                                    elems: Punctuated::new()
-                                });
-                                sig.output = ReturnType::Type(rarrow,
-                                                              Box::new(unit));
-                            }
+                        if let ReturnType::Type(_, ty) = &mut sig.output {
+                                **ty = supersuperfy(&*ty, 1);
                         }
 
                         // Foreign functions are always unsafe.  Mock foreign


### PR DESCRIPTION
Previously Mockall would deliberately generate some `-> ()` return types,
due to the legacy of the expectation! macro.  This commit removes all of
those.  However, there are still a few `-> () + <trait bound>` types in
the generated code.  Those are too much trouble to eliminate, so we
suppress the clippy warning instead.

Fixes #149