### PR TITLE
Fix some comments and doc strings in the generated code

### DIFF
--- a/mockall_derive/src/mock_item.rs
+++ b/mockall_derive/src/mock_item.rs
@@ -140,7 +140,8 @@ impl ToTokens for MockItemModule {
                 let inner = format!("Mock version of the `{}` module", ident);
                 quote!( #[doc = #inner])
             } else {
-                // TODO: write doc string
+                // Typically an extern FFI block.  Not really anything good we
+                // can put in the doc string.
                 quote!(#[allow(missing_docs)])
             }
         };

--- a/mockall_derive/src/mock_item_struct.rs
+++ b/mockall_derive/src/mock_item_struct.rs
@@ -267,7 +267,7 @@ impl ToTokens for MockItemStruct {
         let vis = &self.vis;
         quote!(
             #[allow(non_snake_case)]
-            #[doc(hidden)]
+            #[allow(missing_docs)]
             pub mod #modname {
                 use super::*;
                 #(#priv_mods)*
@@ -342,7 +342,7 @@ impl ToTokens for MockItemTraitImpl {
         let priv_mods = self.methods.priv_mods();
         quote!(
             #[allow(non_snake_case)]
-            #[doc(hidden)]
+            #[allow(missing_docs)]
             pub mod #modname {
                 use super::*;
                 #(#priv_mods)*


### PR DESCRIPTION
The doc strings in question have always been wrong.