### PR TITLE
Disable the warning for incomplete features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 ### Changed
 ### Fixed
+- Suppressed `incomplete_features` warnings in the latest nightly.
+  ([#161](https://github.com/asomers/mockall/pull/161))
+
 ### Removed
 
 ## [0.7.2] - 28 July 2020

--- a/mockall/src/lib.rs
+++ b/mockall/src/lib.rs
@@ -1042,6 +1042,10 @@
 //! [`predicates`]: predicate/index.html
 
 #![cfg_attr(feature = "nightly", feature(specialization))]
+// Allow the incomplete_feature warning for specialization.  We know it's
+// incomplete; that's why it's guarded by the "nightly" feature.
+#![cfg_attr(feature = "nightly", allow(incomplete_features))]
+
 #![cfg_attr(feature = "nightly", feature(doc_cfg))]
 #![deny(intra_doc_link_resolution_failure)]
 


### PR DESCRIPTION
Rust's specialization feature is considered incomplete, and recent
compilers print a warning if you try to use it.  But we know that it's
unstable; that's why it's guarded by the "nightly" flag.