### PR TITLE
Fix three issues with mocking modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased] - ReleaseDate
 ### Added
 ### Changed
+- Mocked modules now have the same visibility as the original module.
+  ([#169](https://github.com/asomers/mockall/pull/169))
+
 ### Fixed
 - Fixed mocking modules including functions that use "impl Trait" or mutable
   arguments.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 ### Changed
 ### Fixed
+- Fixed mocking modules including functions that use "impl Trait" or mutable
+  arguments.
+  ([#169](https://github.com/asomers/mockall/pull/169))
+
 - Fixed mocking methods whose generic types include `super::`.
   ([#167](https://github.com/asomers/mockall/pull/167))
 

--- a/mockall/tests/automock_module.rs
+++ b/mockall/tests/automock_module.rs
@@ -4,6 +4,7 @@
 // mocking modules requires the proc_macro_hygiene feature in the _consumer_
 // code
 #![cfg_attr(feature = "nightly", feature(proc_macro_hygiene))]
+#![deny(warnings)]
 
 use cfg_if::cfg_if;
 
@@ -22,6 +23,8 @@ cfg_if! {
                 pub fn bar1(_x: T) -> i64 {unimplemented!()}
                 // Module functions should be able to use impl Trait, too
                 pub fn baz() -> impl std::fmt::Debug + Send { unimplemented!()}
+                // Module functions can use mutable arguments
+                pub fn bean(mut x: u32) { unimplemented!() }
             }
 
             #[test]

--- a/mockall/tests/automock_module.rs
+++ b/mockall/tests/automock_module.rs
@@ -20,6 +20,8 @@ cfg_if! {
                 pub fn bar(_x: T) -> i64 {unimplemented!()}
                 // We must have a separate method for every should_panic test
                 pub fn bar1(_x: T) -> i64 {unimplemented!()}
+                // Module functions should be able to use impl Trait, too
+                pub fn baz() -> impl std::fmt::Debug + Send { unimplemented!()}
             }
 
             #[test]
@@ -38,6 +40,14 @@ cfg_if! {
                 ctx.expect()
                     .returning(|x| i64::from(x) + 1);
                 assert_eq!(5, mock_foo::bar(4));
+            }
+
+            #[test]
+            fn impl_trait() {
+                let ctx = mock_foo::baz_context();
+                ctx.expect()
+                    .returning(|| Box::new(4));
+                format!("{:?}", mock_foo::baz());
             }
         }
     }

--- a/mockall/tests/automock_module_nonpub.rs
+++ b/mockall/tests/automock_module_nonpub.rs
@@ -39,6 +39,14 @@ cfg_if::cfg_if! {
                         unimplemented!()
                     }
                 }
+
+                #[test]
+                fn returning() {
+                    let ctx = mock_m::foo_context();
+                    ctx.expect()
+                        .returning(|x| x);
+                    mock_m::foo(PubCrateT());
+                }
             }
         }
     }

--- a/mockall_derive/src/mockable_item.rs
+++ b/mockall_derive/src/mockable_item.rs
@@ -3,6 +3,7 @@ use super::*;
 
 /// Performs transformations on a function to make it mockable
 fn mockable_fn(mut item_fn: ItemFn) -> ItemFn {
+    demutify(&mut item_fn.sig.inputs);
     deimplify(&mut item_fn.sig.output);
     item_fn
 }
@@ -157,7 +158,6 @@ impl From<ItemMod> for MockableModule {
             "automock can only mock inline modules, not modules from another file");
             Vec::new()
         };
-        // TODO: demutify funcs
         MockableModule { vis, mock_ident, mod_token, orig_ident, content }
     }
 }

--- a/mockall_derive/src/mockable_item.rs
+++ b/mockall_derive/src/mockable_item.rs
@@ -142,10 +142,7 @@ impl From<(Attrs, ItemForeignMod)> for MockableModule {
 impl From<ItemMod> for MockableModule {
     fn from(mod_: ItemMod) -> MockableModule {
         let span = mod_.span();
-        // TODO: in the future, consider mocking non-public modules
-        let vis = Visibility::Public(VisPublic{
-            pub_token: Token![pub](mod_.vis.span())
-        });
+        let vis = mod_.vis;
         let mock_ident = format_ident!("mock_{}", mod_.ident);
         let orig_ident = Some(mod_.ident);
         let mod_token = mod_.mod_token;


### PR DESCRIPTION
1) methods that return "impl Trait" wouldn't work
2) methods that use mutable arguments would spew warnings
3) The mock module had too generous visibility.