### PR TITLE
Support mocking methods with trait object arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased] - ReleaseDate
 ### Added
+- Support mocking methods with trait object arguments that use implicit
+  lifetimes
+  ([#174](https://github.com/asomers/mockall/pull/174))
+
 ### Changed
 - Raised the minimum supported Rust version (MSRV) to 1.40.0.
   ([#170](https://github.com/asomers/mockall/pull/170))

--- a/mockall/tests/automock_trait_object.rs
+++ b/mockall/tests/automock_trait_object.rs
@@ -1,0 +1,42 @@
+// vim: tw=80
+//! a method that uses unboxed trait object arguments
+#![deny(warnings)]
+
+use mockall::*;
+
+#[automock]
+trait Foo {
+    fn foo(&self, x: &dyn PartialEq<u32>);
+}
+
+// It's almost impossible to construct a Predicate object that will work with
+// trait objects for two reasons:
+// * Mockall requires the predicates to be Debug, and any useful predicate will
+//   also be Eq, Ord, or similar, but Rust only allows up to one non-auto trait
+//   per trait object.
+// * The predicate is requird to meet the HRTB
+//   for<'a> Predicate<(dyn Trait + 'a)>
+//   That's not impossible, but Mockall doesn't provide any way to construct
+//   such a predicate.
+// So, use of `with` is pretty much limited to predicates like `always` and
+// `function`.
+#[test]
+fn with() {
+    let mut mock = MockFoo::new();
+    mock.expect_foo()
+        .with(predicate::always())
+        .return_const(());
+    mock.foo(&42u32)
+}
+
+/// trait object arguments can't be matched with `predicate::eq`, because
+/// `PartialEq<Self>` cannot be made into a trait object.  But withf still
+/// works.
+#[test]
+fn withf() {
+    let mut mock = MockFoo::new();
+    mock.expect_foo()
+        .withf(|x| *x == 42u32)
+        .return_const(());
+    mock.foo(&42u32);
+}


### PR DESCRIPTION
Such arguments can be matched with `withf`.  However, `with` is useless
for such arguments, because it isn't possible to construct a useful
Predicate that works with them.  That's unlikely to change in future
versions of Mockall.

Fixes #152