### PR TITLE
Generate less code when mocking traits with no non-static methods

### DIFF
--- a/mockall/tests/automock_constructor_in_generic_trait.rs
+++ b/mockall/tests/automock_constructor_in_generic_trait.rs
@@ -1,6 +1,5 @@
 // vim: tw=80
 //! A generic trait with a non-generic constructor method.
-#![allow(unused)]
 #![deny(warnings)]
 
 use mockall::*;

--- a/mockall/tests/automock_constructor_in_trait_with_args.rs
+++ b/mockall/tests/automock_constructor_in_trait_with_args.rs
@@ -2,7 +2,6 @@
 //! A struct with a constructor method named "new" that has arguments.
 //! mockall should mock the provided method, and not autogenerate a 0-argument
 //! "new" method.
-#![allow(unused)]
 #![deny(warnings)]
 
 use mockall::*;

--- a/mockall/tests/automock_generic_constructor.rs
+++ b/mockall/tests/automock_generic_constructor.rs
@@ -1,6 +1,5 @@
 // vim: tw=80
 //! A non-generic struct can have a generic constructor method
-#![allow(unused)]
 #![deny(warnings)]
 
 use mockall::*;

--- a/mockall/tests/automock_generic_static_method.rs
+++ b/mockall/tests/automock_generic_static_method.rs
@@ -1,6 +1,5 @@
 // vim: tw=80
 //! generic static methods with generic arguments
-#![allow(unused)]
 #![deny(warnings)]
 
 use mockall::*;

--- a/mockall/tests/automock_generic_struct_with_static_method.rs
+++ b/mockall/tests/automock_generic_struct_with_static_method.rs
@@ -2,7 +2,6 @@
 //! static non-generic methods of generic structs shouldn't require any special
 //! treatment when mocking.  Prior to version 0.3.0, the struct's generic
 //! parameters had to be duplicated as generic parameters of the method.
-#![allow(unused)]
 #![deny(warnings)]
 
 use mockall::*;

--- a/mockall/tests/automock_nonsend.rs
+++ b/mockall/tests/automock_nonsend.rs
@@ -92,7 +92,6 @@ mod refmut_method {
 }
 
 pub mod static_method {
-    #![allow(unused)]   // https://github.com/asomers/mockall/issues/177
     use super::*;
 
     #[automock]

--- a/mockall/tests/automock_static_method.rs
+++ b/mockall/tests/automock_static_method.rs
@@ -1,6 +1,5 @@
 // vim: tw=80
 //! automocking a trait with a static method
-#![allow(unused)]
 #![deny(warnings)]
 
 use mockall::*;

--- a/mockall/tests/mock_multiple_traits.rs
+++ b/mockall/tests/mock_multiple_traits.rs
@@ -1,6 +1,5 @@
 // vim: tw=80
 //! A struct that implements multiple traits
-#![allow(unused)]
 #![deny(warnings)]
 
 use mockall::*;


### PR DESCRIPTION
Eliminates "error: field is never read" warnings

Fixes #177