### PR TITLE
Add support for mocking associated consts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased] - ReleaseDate
 ### Added
+- Added support for mocking structs and traits with associated constants.
+  ([#187](https://github.com/asomers/mockall/pull/187))
+
 - Methods returning slices can now be mocked.  Their expectations take `Vec`s.
   ([#185](https://github.com/asomers/mockall/pull/185))
 

--- a/mockall/src/lib.rs
+++ b/mockall/src/lib.rs
@@ -1156,6 +1156,24 @@ pub mod examples;
 /// }
 /// ```
 ///
+/// You can also mock a trait impl on a struct:
+/// ```
+/// # use mockall_derive::*;
+/// pub trait Foo {
+///     fn foo(&self, key: i16);
+/// }
+/// struct Bar{}
+/// #[automock]
+/// impl Foo for Bar {
+///     fn foo(&self, key: i16){
+///         // ...
+///         # unimplemented!()
+///     }
+/// }
+///
+/// let mock = MockBar::new();
+/// ```
+///
 /// Mocking a trait with associated types requires adding a metaitem to the
 /// attribute:
 /// ```

--- a/mockall/tests/automock_associated_const.rs
+++ b/mockall/tests/automock_associated_const.rs
@@ -1,0 +1,58 @@
+// vim: tw=80
+//! A trait with an associated constant
+//!
+//! It's not possible to automock the trait, like:
+//! ```
+//! #[automock]
+//!     trait Foo {
+//!     const X: i32;
+//! }
+//! ```
+//! because there's no way to set the value of X on MockFoo.
+//!
+//! But it _is_ possible to automock the trait implementation, like this:
+//! ```
+//! struct Bar {}
+//! #[automock]
+//! impl Foo for Bar {
+//!     const X: i32;
+//! }
+//! ```
+//!
+//! https://github.com/asomers/mockall/issues/97
+#![deny(warnings)]
+
+use mockall::*;
+
+trait Foo {
+    const X: i32;
+
+    fn x_plus_one(&self) -> i32 {
+        Self::X + 1
+    }
+}
+
+#[allow(dead_code)]
+struct Bar {}
+
+#[automock]
+impl Foo for Bar {
+    const X: i32 = 42;
+}
+
+#[allow(dead_code)]
+pub struct Baz {}
+#[automock]
+impl Baz {
+    pub const Y: i32 = 69;
+}
+
+#[test]
+fn default_method() {
+    assert_eq!(MockBar::new().x_plus_one(), 43);
+}
+
+#[test]
+fn on_a_struct() {
+    assert_eq!(MockBaz::Y, 69);
+}

--- a/mockall/tests/mock_associated_const.rs
+++ b/mockall/tests/mock_associated_const.rs
@@ -1,0 +1,35 @@
+// vim: tw=80
+//! A trait with an associated constant
+//!
+//! https://github.com/asomers/mockall/issues/97
+#![deny(warnings)]
+
+use mockall::*;
+
+trait Foo {
+    const X: i32;
+
+    fn x_plus_one(&self) -> i32 {
+        Self::X + 1
+    }
+}
+
+mock! {
+    Foo {
+        const Y: i32 = 69;
+        fn foo(&self);
+    }
+    trait Foo {
+        const X: i32 = 42;
+    }
+}
+
+#[test]
+fn default_method() {
+    assert_eq!(MockFoo::new().x_plus_one(), 43);
+}
+
+#[test]
+fn on_the_struct() {
+    assert_eq!(MockFoo::Y, 69);
+}

--- a/mockall_derive/src/mock_item_struct.rs
+++ b/mockall_derive/src/mock_item_struct.rs
@@ -97,6 +97,7 @@ impl Methods {
 
 pub(crate) struct MockItemStruct {
     attrs: Vec<Attribute>,
+    consts: Vec<ImplItemConst>,
     generics: Generics,
     /// Does the original struct have a `new` method?
     has_new: bool,
@@ -174,6 +175,7 @@ impl From<MockableStruct> for MockItemStruct {
 
         MockItemStruct {
             attrs: mockable.attrs,
+            consts: mockable.consts,
             generics,
             has_new,
             methods,
@@ -190,6 +192,7 @@ impl ToTokens for MockItemStruct {
         let attrs = AttrFormatter::new(&self.attrs)
             .async_trait(false)
             .format();
+        let consts = &self.consts;
         let struct_name = &self.name;
         let (ig, tg, wc) = self.generics.split_for_impl();
         let modname = &self.modname;
@@ -269,6 +272,7 @@ impl ToTokens for MockItemStruct {
             }
             #(#substructs)*
             impl #ig #struct_name #tg #wc {
+                #(#consts)*
                 #(#calls)*
                 #(#contexts)*
                 #(#expects)*


### PR DESCRIPTION
automock can now mock a trait impl with an associated const.  It can't
mock the trait declaration, because in that case there's no way to set
the value of the associated const on the mock struct.  Of course, if the
trait itself has a default value for the const, then automock will work.
automock can now mock a struct impl with an associated const.

mock! can now mock structs with both inherent associated consts, and
associated consts on their trait impls.

Fixes #97