### PR TITLE
Silence `clippy::ptr_arg` warning

### DIFF
--- a/mockall/src/lib.rs
+++ b/mockall/src/lib.rs
@@ -1,8 +1,8 @@
 // vim: tw=80
 //! A powerful mock object library for Rust.
 //!
-//! Mockall provides provides tools to create mock versions of almost any trait
-//! or struct.  They can be used in unit tests as a stand-in for the real
+//! Mockall provides tools to create mock versions of almost any trait
+//! or struct. They can be used in unit tests as a stand-in for the real
 //! object.
 //!
 //! # Usage

--- a/mockall/tests/automock_string_arguments.rs
+++ b/mockall/tests/automock_string_arguments.rs
@@ -1,0 +1,31 @@
+// vim: tw=80
+//! A method with `String` arguments
+#![deny(warnings)]
+
+use mockall::*;
+
+#[automock]
+trait Foo {
+    fn foo(&self, x: String);
+}
+
+mod withf {
+    use super::*;
+
+    #[test]
+    #[should_panic(expected = "MockFoo::foo: No matching expectation found")]
+    fn fail() {
+        let mut mock = MockFoo::new();
+        mock.expect_foo().withf(|sl| sl == "abc").return_const(());
+        let x = String::from("abcd");
+        mock.foo(x);
+    }
+
+    #[test]
+    fn ok() {
+        let mut mock = MockFoo::new();
+        mock.expect_foo().withf(|sl| sl == "abc").return_const(());
+        let x = String::from("abc");
+        mock.foo(x);
+    }
+}

--- a/mockall/tests/automock_vec_arguments.rs
+++ b/mockall/tests/automock_vec_arguments.rs
@@ -1,0 +1,35 @@
+// vim: tw=80
+//! A method with `Vec<T>` arguments
+#![deny(warnings)]
+
+use mockall::*;
+
+#[automock]
+trait Foo {
+    fn foo<T: 'static>(&self, x: Vec<T>);
+}
+
+mod withf {
+    use super::*;
+
+    #[test]
+    #[should_panic(expected = "MockFoo::foo: No matching expectation found")]
+    fn fail() {
+        let mut mock = MockFoo::new();
+        mock.expect_foo::<i32>()
+            .withf(|sl| sl == &vec![1, 2, 3])
+            .return_const(());
+        let x = vec![1, 2, 3, 4];
+        mock.foo(x);
+    }
+
+    #[test]
+    fn ok() {
+        let mut mock = MockFoo::new();
+        mock.expect_foo::<i32>()
+            .withf(|sl| sl == &vec![1, 2, 3])
+            .return_const(());
+        let x = vec![1, 2, 3];
+        mock.foo(x);
+    }
+}

--- a/mockall/tests/mock_string_arguments.rs
+++ b/mockall/tests/mock_string_arguments.rs
@@ -1,0 +1,36 @@
+// vim: tw=80
+//! A method with `String` arguments
+#![deny(warnings)]
+
+use mockall::*;
+
+trait Foo {
+    fn foo(&self, x: String);
+}
+
+mock! {
+    Foo {
+        fn foo(&self, x: String);
+    }
+}
+
+mod withf {
+    use super::*;
+
+    #[test]
+    #[should_panic(expected = "MockFoo::foo: No matching expectation found")]
+    fn fail() {
+        let mut mock = MockFoo::new();
+        mock.expect_foo().withf(|sl| sl == "abc").return_const(());
+        let x = String::from("abcd");
+        mock.foo(x);
+    }
+
+    #[test]
+    fn ok() {
+        let mut mock = MockFoo::new();
+        mock.expect_foo().withf(|sl| sl == "abc").return_const(());
+        let x = String::from("abc");
+        mock.foo(x);
+    }
+}

--- a/mockall/tests/mock_vec_arguments.rs
+++ b/mockall/tests/mock_vec_arguments.rs
@@ -1,0 +1,40 @@
+// vim: tw=80
+//! A method with `Vec<T>` arguments
+#![deny(warnings)]
+
+use mockall::*;
+
+trait Foo {
+    fn foo<T: 'static>(&self, x: Vec<T>);
+}
+
+mock! {
+    Foo {
+        fn foo<T: 'static>(&self, x: Vec<T>);
+    }
+}
+
+mod withf {
+    use super::*;
+
+    #[test]
+    #[should_panic(expected = "MockFoo::foo: No matching expectation found")]
+    fn fail() {
+        let mut mock = MockFoo::new();
+        mock.expect_foo::<i32>()
+            .withf(|sl| sl == &vec![1, 2, 3])
+            .return_const(());
+        let x = vec![1, 2, 3, 4];
+        mock.foo(x);
+    }
+
+    #[test]
+    fn ok() {
+        let mut mock = MockFoo::new();
+        mock.expect_foo::<i32>()
+            .withf(|sl| sl == &vec![1, 2, 3])
+            .return_const(());
+        let x = vec![1, 2, 3];
+        mock.foo(x);
+    }
+}

--- a/mockall_derive/src/mock_function.rs
+++ b/mockall_derive/src/mock_function.rs
@@ -821,6 +821,7 @@ impl<'a> ToTokens for Common<'a> {
                     self.times.is_done()
                 }
 
+                #[allow(clippy::ptr_arg)]
                 fn matches #lg (&self, #( #argnames: &#predty, )*) -> bool {
                     self.matcher.lock().unwrap().matches(#(#argnames, )*)
                 }
@@ -934,6 +935,7 @@ impl<'a> ToTokens for CommonExpectationMethods<'a> {
             }
 
             /// Validate this expectation's matcher.
+            #[allow(clippy::ptr_arg)]
             fn matches #lg (&self, #(#argnames: &#predty, )*) -> bool {
                 self.common.matches(#(#argnames, )*)
             }
@@ -1536,6 +1538,7 @@ impl<'a> ToTokens for Matcher<'a> {
                 _Phantom(Box<dyn Fn(#(#fn_params,)*) + Send>)
             }
             impl #ig Matcher #tg #wc {
+                #[allow(clippy::ptr_arg)]
                 fn matches #lg (&self, #( #argnames: &#predty, )*) -> bool {
                     match self {
                         Matcher::Always => true,


### PR DESCRIPTION
Mocking method with `String` or `Vec<T>` arguments cause `clippy::ptr_arg` warning in user code:
```rust
#[automock]
trait Foo {
    fn foo(&self, x: String);
}
```
```
error: writing `&String` instead of `&str` involves a new object where a slice will do.
 --> mockall/tests/automock_string_arguments.rs:7:1
  |
7 | #[automock]
  | ^^^^^^^^^^^
  |
note: the lint level is defined here
 --> mockall/tests/automock_string_arguments.rs:3:9
  |
3 | #![deny(warnings)]
  |         ^^^^^^^^
  = note: `#[deny(clippy::ptr_arg)]` implied by `#[deny(warnings)]`
  = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#ptr_arg
  = note: this error originates in an attribute macro (in Nightly builds, run with -Z macro-backtrace for more info)
```

Silence the warning.