### PR TITLE
proc_macro_hygiene is no longer needed to automock modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased] - ReleaseDate
 ### Added
+
+- `#[automock]` now works on modules even without the `nightly` feature, and no
+  longer requires `#[feature(proc_macro_hygiene)]`
+  ([#198](https://github.com/asomers/mockall/pull/198))
+
 ### Changed
 ### Fixed
 

--- a/mockall/src/lib.rs
+++ b/mockall/src/lib.rs
@@ -959,14 +959,10 @@
 //! ## Modules
 //!
 //! In addition to mocking foreign functions, Mockall can also derive mocks for
-//! entire modules of Rust functions,  This requires the **nightly** feature,
-//! and it requires the consuming crate to enable `feature(proc_macro_hygiene)`.
-//! Usage is the same as when mocking foreign functions, except that the mock
-//! module name is automatically derived.
+//! entire modules of Rust functions.  Usage is the same as when mocking foreign
+//! functions, except that the mock module name is automatically derived.
 //!
-#![cfg_attr(feature = "nightly", doc = "```")]
-#![cfg_attr(not(feature = "nightly"), doc = "```ignore")]
-//! #![feature(proc_macro_hygiene)]
+//! ```
 //! # use mockall::*;
 //! # use cfg_if::cfg_if;
 //! mod outer {

--- a/mockall/tests/automock_attrs.rs
+++ b/mockall/tests/automock_attrs.rs
@@ -1,31 +1,24 @@
 // vim: tw=80
 //! Attributes are applied to the mock object, too.
 #![allow(unused)]
-#![cfg_attr(feature = "nightly", feature(proc_macro_hygiene))]
 #![deny(warnings)]
-
-use cfg_if::cfg_if;
 
 use mockall::*;
 
-cfg_if! {
-    if #[cfg(feature = "nightly")] {
-        #[automock]
-        mod m {
-            #[cfg(target_os = "multics")]
-            pub fn bloob(x: DoesNotExist) -> i64 {unimplemented!()}
-            #[cfg(not(target_os = "multics"))]
-            pub fn blarg(x: i32) -> i64 {unimplemented!()}
-        }
+#[automock]
+mod m {
+    #[cfg(target_os = "multics")]
+    pub fn bloob(x: DoesNotExist) -> i64 {unimplemented!()}
+    #[cfg(not(target_os = "multics"))]
+    pub fn blarg(x: i32) -> i64 {unimplemented!()}
+}
 
-        #[test]
-        fn returning() {
-            let ctx = mock_m::blarg_context();
-            ctx.expect()
-                .returning(|x| i64::from(x) + 1);
-            assert_eq!(5, mock_m::blarg(4));
-        }
-    }
+#[test]
+fn returning() {
+    let ctx = mock_m::blarg_context();
+    ctx.expect()
+        .returning(|x| i64::from(x) + 1);
+    assert_eq!(5, mock_m::blarg(4));
 }
 
 pub struct A{}

--- a/mockall/tests/automock_module.rs
+++ b/mockall/tests/automock_module.rs
@@ -2,57 +2,46 @@
 //! Mocking an entire module of functions
 #![deny(warnings)]
 
-// mocking modules requires the proc_macro_hygiene feature in the _consumer_
-// code
-#![cfg_attr(feature = "nightly", feature(proc_macro_hygiene))]
-#![deny(warnings)]
+mod m {
+    use mockall::*;
+    type T = u32;
 
-use cfg_if::cfg_if;
+    #[automock]
+    #[allow(unused)]
+    mod foo {
+        use super::T;
+        pub fn bar(_x: T) -> i64 {unimplemented!()}
+        // We must have a separate method for every should_panic test
+        pub fn bar1(_x: T) -> i64 {unimplemented!()}
+        // Module functions should be able to use impl Trait, too
+        pub fn baz() -> impl std::fmt::Debug + Send { unimplemented!()}
+        // Module functions can use mutable arguments
+        pub fn bean(mut x: u32) { unimplemented!() }
+    }
 
-cfg_if! {
-    if #[cfg(feature = "nightly")] {
-        mod m {
-            use mockall::*;
-            type T = u32;
+    #[test]
+    #[should_panic(expected = "mock_foo::bar1: No matching expectation found")]
+    fn with_no_matches() {
+        let ctx = mock_foo::bar1_context();
+        ctx.expect()
+            .with(predicate::eq(4))
+            .return_const(0);
+        mock_foo::bar1(5);
+    }
 
-            #[automock]
-            #[allow(unused)]
-            mod foo {
-                use super::T;
-                pub fn bar(_x: T) -> i64 {unimplemented!()}
-                // We must have a separate method for every should_panic test
-                pub fn bar1(_x: T) -> i64 {unimplemented!()}
-                // Module functions should be able to use impl Trait, too
-                pub fn baz() -> impl std::fmt::Debug + Send { unimplemented!()}
-                // Module functions can use mutable arguments
-                pub fn bean(mut x: u32) { unimplemented!() }
-            }
+    #[test]
+    fn returning() {
+        let ctx = mock_foo::bar_context();
+        ctx.expect()
+            .returning(|x| i64::from(x) + 1);
+        assert_eq!(5, mock_foo::bar(4));
+    }
 
-            #[test]
-            #[should_panic(expected = "mock_foo::bar1: No matching expectation found")]
-            fn with_no_matches() {
-                let ctx = mock_foo::bar1_context();
-                ctx.expect()
-                    .with(predicate::eq(4))
-                    .return_const(0);
-                mock_foo::bar1(5);
-            }
-
-            #[test]
-            fn returning() {
-                let ctx = mock_foo::bar_context();
-                ctx.expect()
-                    .returning(|x| i64::from(x) + 1);
-                assert_eq!(5, mock_foo::bar(4));
-            }
-
-            #[test]
-            fn impl_trait() {
-                let ctx = mock_foo::baz_context();
-                ctx.expect()
-                    .returning(|| Box::new(4));
-                format!("{:?}", mock_foo::baz());
-            }
-        }
+    #[test]
+    fn impl_trait() {
+        let ctx = mock_foo::baz_context();
+        ctx.expect()
+            .returning(|| Box::new(4));
+        format!("{:?}", mock_foo::baz());
     }
 }

--- a/mockall/tests/automock_module_nonpub.rs
+++ b/mockall/tests/automock_module_nonpub.rs
@@ -2,53 +2,45 @@
 //! bare functions can use non-public types, as long as the object's visibility is compatible.
 #![deny(warnings)]
 
-// mocking modules requires the proc_macro_hygiene feature in the _consumer_
-// code
-#![cfg_attr(feature = "nightly", feature(proc_macro_hygiene))]
-
 #[allow(unused)]
-cfg_if::cfg_if! {
-    if #[cfg(feature = "nightly")] {
-        mod outer {
-            struct SuperT();
+mod outer {
+    struct SuperT();
 
-            mod inner {
-                use mockall::automock;
+    mod inner {
+        use mockall::automock;
 
-                pub(crate) struct PubCrateT();
-                struct PrivT();
+        pub(crate) struct PubCrateT();
+        struct PrivT();
 
-                #[automock]
-                #[allow(unused)]
-                mod m {
-                    use super::*;
+        #[automock]
+        #[allow(unused)]
+        mod m {
+            use super::*;
 
-                    pub(crate) fn foo(x: PubCrateT) -> PubCrateT {
-                        unimplemented!()
-                    }
-                    pub(super) fn bar(x: PrivT) -> PrivT {
-                        unimplemented!()
-                    }
-                    pub(in super::super) fn baz(x: super::super::SuperT)
-                        -> super::super::SuperT
-                    {
-                        unimplemented!()
-                    }
-                    pub(in crate::outer) fn bang(x: crate::outer::SuperT)
-                        -> crate::outer::SuperT
-                    {
-                        unimplemented!()
-                    }
-                }
-
-                #[test]
-                fn returning() {
-                    let ctx = mock_m::foo_context();
-                    ctx.expect()
-                        .returning(|x| x);
-                    mock_m::foo(PubCrateT());
-                }
+            pub(crate) fn foo(x: PubCrateT) -> PubCrateT {
+                unimplemented!()
             }
+            pub(super) fn bar(x: PrivT) -> PrivT {
+                unimplemented!()
+            }
+            pub(in super::super) fn baz(x: super::super::SuperT)
+                -> super::super::SuperT
+            {
+                unimplemented!()
+            }
+            pub(in crate::outer) fn bang(x: crate::outer::SuperT)
+                -> crate::outer::SuperT
+            {
+                unimplemented!()
+            }
+        }
+
+        #[test]
+        fn returning() {
+            let ctx = mock_m::foo_context();
+            ctx.expect()
+                .returning(|x| x);
+            mock_m::foo(PubCrateT());
         }
     }
 }


### PR DESCRIPTION
This is a new unannounced feature in Rust 1.42.0.