### PR TITLE
Deny all warnings during CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -5,17 +5,20 @@ test_task:
         image: rust:1.42.0
       env:
         RUSTFLAGS: -Dwarnings
+        RUSTDOCFLAGS: -Dwarnings
     - name: stable
       container:
         image: rust:latest
       env:
         RUSTFLAGS: -Dwarnings
+        RUSTDOCFLAGS: -Dwarnings
     - name: nightly
       container:
         image: rustlang/rust:nightly
       env:
         CARGO_ARGS: --all-features
         RUSTFLAGS: -Dwarnings
+        RUSTDOCFLAGS: -Dwarnings
   cargo_cache:
     folder: $CARGO_HOME/registry
   build_script:
@@ -39,6 +42,7 @@ minver_task:
     image: rustlang/rust:nightly
   env:
     RUSTFLAGS: -Dwarnings
+    RUSTDOCFLAGS: -Dwarnings
   cargo_cache:
     folder: $CARGO_HOME/registry
   test_script:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -3,14 +3,19 @@ test_task:
     - name: 1.42.0
       container:
         image: rust:1.42.0
+      env:
+        RUSTFLAGS: -Dwarnings
     - name: stable
       container:
         image: rust:latest
+      env:
+        RUSTFLAGS: -Dwarnings
     - name: nightly
       container:
         image: rustlang/rust:nightly
       env:
         CARGO_ARGS: --all-features
+        RUSTFLAGS: -Dwarnings
   cargo_cache:
     folder: $CARGO_HOME/registry
   build_script:
@@ -30,9 +35,10 @@ minver_task:
     - stable
     - nightly
     - clippy
-  matrix:
-    - container:
-       image: rustlang/rust:nightly
+  container:
+    image: rustlang/rust:nightly
+  env:
+    RUSTFLAGS: -Dwarnings
   cargo_cache:
     folder: $CARGO_HOME/registry
   test_script:

--- a/mockall/src/lib.rs
+++ b/mockall/src/lib.rs
@@ -1077,7 +1077,6 @@
 #![cfg_attr(feature = "nightly", allow(incomplete_features))]
 
 #![cfg_attr(feature = "nightly", feature(doc_cfg))]
-#![deny(broken_intra_doc_links)]
 #![cfg_attr(test, deny(warnings))]
 
 use downcast::*;


### PR DESCRIPTION
Previously we only denied all warnings during unit tests.  This denies
them during the regular build too, but only during CI.