### PR TITLE
Add Mockall double

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,2 +1,2 @@
 [workspace]
-members = ["mockall", "mockall_derive"]
+members = ["mockall", "mockall_derive", "mockall_double"]

--- a/mockall/Cargo.toml
+++ b/mockall/Cargo.toml
@@ -35,6 +35,7 @@ mockall_derive = { version = "= 0.8.0", path = "../mockall_derive" }
 [dev-dependencies]
 async-trait = "0.1.38"
 futures = "0.3"
+mockall_double = { version = "0.1.0", path = "../mockall_double" }
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"

--- a/mockall/Cargo.toml
+++ b/mockall/Cargo.toml
@@ -43,3 +43,10 @@ serde_json = "1.0"
 [[example]]
 name = "serde"
 crate-type = ["lib"]
+
+[package.metadata.release]
+tag-prefix = ""
+pre-release-replacements = [
+    { file="../CHANGELOG.md", search="Unreleased", replace="{{version}}" },
+    { file="../CHANGELOG.md", search="ReleaseDate", replace="{{date}}" }
+]

--- a/mockall/examples/ffi.rs
+++ b/mockall/examples/ffi.rs
@@ -1,0 +1,35 @@
+// vim: tw=80
+//! An example of unit testing involving mocked FFI functions
+
+#![cfg(unix)]
+
+#[cfg(test)]
+use mockall::automock;
+use mockall_double::double;
+
+#[cfg_attr(test, automock)]
+pub mod mockable_ffi {
+    extern "C" {
+        pub fn getuid() -> u32;
+    }
+}
+
+#[double]
+use mockable_ffi as ffi;
+
+fn getuid() -> u32 {
+    unsafe { ffi::getuid() }
+}
+
+fn main() {
+    println!("My uid is {}", getuid() );
+}
+
+
+#[test]
+fn getuid_test() {
+    let ctx = ffi::getuid_context();
+    ctx.expect()
+        .return_const(42u32);
+    getuid();
+}

--- a/mockall/src/lib.rs
+++ b/mockall/src/lib.rs
@@ -581,12 +581,13 @@
 //! Mockall mocks structs as well as traits.  The problem here is a namespace
 //! problem: it's hard to supply the mock object to your code under test,
 //! because it has a different name.  The solution is to alter import paths
-//! during test.  The [`cfg-if`] crate helps.
+//! during test.  The easiest way to do that is with the
+//! [`mockall_double`](https://docs.rs/mockall/latest/mockall_double) crate.
 //!
 //! [`#[automock]`](attr.automock.html)
 //! works for structs that have a single `impl` block:
 //! ```no_run
-//! # use cfg_if::cfg_if;
+//! use mockall_double::double;
 //! mod thing {
 //!     use mockall::automock;
 //!     pub struct Thing{}
@@ -599,13 +600,8 @@
 //!     }
 //! }
 //!
-//! cfg_if! {
-//!     if #[cfg(test)] {
-//!         use self::thing::MockThing as Thing;
-//!     } else {
-//!         use self::thing::Thing;
-//!     }
-//! }
+//! #[double]
+//! use thing::Thing;
 //!
 //! fn do_stuff(thing: &Thing) -> u32 {
 //!     thing.foo()
@@ -913,11 +909,12 @@
 //!
 //! In addition to mocking types, Mockall can also derive mocks for
 //! entire modules of Rust functions.  Mockall will generate a new module named
-//! "mock_xxx", if "xxx" is the original module's name.
+//! "mock_xxx", if "xxx" is the original module's name.  You can also use
+//! `#[double]` to selectively import the mock module.
 //!
 //! ```
 //! # use mockall::*;
-//! # use cfg_if::cfg_if;
+//! # use mockall_double::*;
 //! mod outer {
 //!     use mockall::automock;
 //!     #[automock()]
@@ -929,13 +926,8 @@
 //!     }
 //! }
 //!
-//! cfg_if! {
-//!     if #[cfg(test)] {
-//!         use outer::mock_inner as inner;
-//!     } else {
-//!         use outer::inner;
-//!     }
-//! }
+//! #[double]
+//! use outer::inner;
 //!
 //! #[cfg(test)]
 //! mod t {
@@ -956,12 +948,10 @@
 //!
 //! One reason to mock modules is when working with foreign functions.  Modules
 //! may contain foreign functions, even though structs and traits may not.  Like
-//! static methods, the expectations are global.  Like mocking structs, you'll
-//! probably have to fiddle with your imports to make the mock function
-//! accessible.
+//! static methods, the expectations are global.
 //!
 //! ```
-//! # use cfg_if::cfg_if;
+//! # use mockall_double::*;
 //! mod outer {
 //!     # use mockall::*;
 //!     #[automock]
@@ -972,13 +962,8 @@
 //!     }
 //! }
 //!
-//! cfg_if! {
-//!     if #[cfg(test)] {
-//!         use outer::mock_ffi as ffi;
-//!     } else {
-//!         use outer::ffi;
-//!     }
-//! }
+//! #[double]
+//! use outer::ffi;
 //!
 //! fn do_stuff() -> i64 {
 //!     unsafe{ ffi::foo(42) }

--- a/mockall_derive/Cargo.toml
+++ b/mockall_derive/Cargo.toml
@@ -29,3 +29,8 @@ syn = { version = "1.0.15", features = ["extra-traits", "full"] }
 
 [dev-dependencies]
 pretty_assertions = "0.5"
+
+# Skip tagging and pushing.  Those will be done by the mockall crate
+[package.metadata.release]
+disable-tag = true
+disable-push = true

--- a/mockall_double/Cargo.toml
+++ b/mockall_double/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "mockall_double"
+version = "0.1.0"
+authors = ["Alan Somers <asomers@gmail.com>"]
+license = "MIT/Apache-2.0"
+repository = "https://github.com/asomers/mockall"
+categories = ["development-tools::testing"]
+keywords = ["mock", "mocking", "testing"]
+documentation = "https://docs.rs/mockall_derive"
+edition = "2018"
+description = """
+Test double adapter for Mockall
+"""
+
+[lib]
+proc-macro = true
+
+[features]
+nightly = ["proc-macro2/nightly"]
+
+[dependencies]
+cfg-if = "0.1.6"
+proc-macro2 = "1.0"
+quote = "1.0"
+syn = { version = "1.0.15", features = ["extra-traits", "full"] }

--- a/mockall_double/README.md
+++ b/mockall_double/README.md
@@ -1,0 +1,88 @@
+# mockall_double
+
+A double test adapter that works well with Mockall.
+
+[![Build Status](https://api.cirrus-ci.com/github/asomers/mockall.svg)](https://cirrus-ci.com/github/asomers/mockall)
+[![Crates.io](https://img.shields.io/crates/v/mockall_double.svg)](https://crates.io/crates/mockall_double)
+[![Documentation](https://docs.rs/mockall_double/badge.svg)](https://docs.rs/mockall_double)
+
+## Overview
+
+Mockall can easily create a mock version of a struct.  But how does one
+convince the code under test to use the mock struct instead of the real one?
+In Rust, it's necessary to replace the real struct at compile time.  That's
+very easy to do with a few `#[cfg(test)]` statements.  But mockall_double makes
+it even easier.
+
+## Usage
+
+Typically mockall is only used by unit tests, so it can be a dev-dependency.
+But mockall_double must be a full dependency.  To use it this way, add this to
+your `Cargo.toml`:
+
+```toml
+[dependencies]
+mockall_double = "0.1.0"
+
+[dev-dependencies]
+mockall = "0.8.0"
+```
+
+Then use it like this:
+
+```rust
+use mockall_double::double;
+
+mod mockable {
+    #[cfg(test)]
+    use mockall::automock;
+
+    pub struct Foo {}
+    #[cfg_attr(test, automock)]
+    impl Foo {
+        pub fn foo(&self, x: u32) -> u32 {
+            // ...
+            0
+        }
+    }
+}
+
+#[double]
+use mockable::Foo;
+
+fn bar(f: Foo) -> u32 {
+    f.foo(42)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bar_test() {
+        let mut mock = Foo::new();
+        mock.expect_foo()
+            .returning(|x| x + 1);
+        assert_eq!(43, bar(mock));
+    }
+}
+```
+
+See the [API docs](https://docs.rs/mockall_double) for more information.
+
+# Minimum Supported Rust Version (MSRV)
+
+Mockall_double is tested with the same MSRV as Mockall itself.  Currently, that's Rust 1.42.0.  mockall_double's MSRV will not be changed in the future without bumping the major or minor version.
+
+# License
+
+`mockall_double` is primarily distributed under the terms of both the MIT
+license and the Apache License (Version 2.0).
+
+See LICENSE-APACHE, and LICENSE-MIT for details
+
+# Acknowledgements
+
+mockall_double is inspired by Jason Grlicky's
+[double](https://crates.io/crates/double) crate, but tweaked to work better
+with Mockall's naming conventions.

--- a/mockall_double/src/lib.rs
+++ b/mockall_double/src/lib.rs
@@ -1,0 +1,301 @@
+// vim: tw=80
+//! Test double adapter for use with Mockall
+//!
+//! This crate provides [`[#double]`](macro@double), which can swap in Mock
+//! objects for real objects while in test mode.  It's intended to be used in
+//! tandem with the [`mockall`](https://docs.rs/mockall/latest/mockall) crate.
+//! However, it is defined in its own crate so that the bulk of Mockall can
+//! remain a dev-dependency, instead of a regular dependency.
+
+#![cfg_attr(feature = "nightly", feature(proc_macro_diagnostic))]
+#![cfg_attr(test, deny(warnings))]
+extern crate proc_macro;
+
+use cfg_if::cfg_if;
+use proc_macro2::{Span, TokenStream};
+use quote::{format_ident, quote};
+use syn::{
+    *,
+    spanned::Spanned
+};
+
+cfg_if! {
+    // proc-macro2's Span::unstable method requires the nightly feature, and it
+    // doesn't work in test mode.
+    // https://github.com/alexcrichton/proc-macro2/issues/159
+    if #[cfg(all(feature = "nightly", not(test)))] {
+        fn compile_error(span: Span, msg: &'static str) {
+            span.unstable()
+                .error(msg)
+                .emit();
+        }
+    } else {
+        fn compile_error(_span: Span, msg: &str) {
+            panic!("{}.  More information may be available when mockall_double is built with the \"nightly\" feature.", msg);
+        }
+    }
+}
+
+fn do_double(_attrs: TokenStream, input: TokenStream) -> TokenStream {
+    let mut use_stmt: ItemUse = match parse2(input.clone()) {
+        Ok(u) => u,
+        Err(e) => return e.to_compile_error()
+    };
+    mock_itemuse(&mut use_stmt);
+    quote!(
+        #[cfg(not(test))]
+        #input
+        #[cfg(test)]
+        #use_stmt
+    )
+}
+
+/// Import a mock type in test mode, or a real type otherwise.
+///
+/// In a regular build, this macro is a no-op.  But when `#[cfg(test)]`, it
+/// substitutes "MockXXX" for any imported "XXX".  This makes it easy to to use
+/// mock objects, especially structs, in your unit tests.
+///
+/// This macro uses the same naming convention as
+/// [`mockall`](https://docs.rs/mockall/latest/mockall), but doesn't strictly
+/// require it.  It can work with hand-built Mock objects, or any other crate
+/// using the same naming convention.
+///
+/// This is the most common way to use `#[double]`.  In order to replace a type,
+/// it must come from a separate module.  So to mock type `Foo`, place it into a
+/// submodule, along with its mock counterpart.  Then simply import `Foo` with
+/// `#[double]` like this:
+/// ```no_run
+/// # use mockall_double::double;
+/// mod foo {
+///     pub(super) struct Foo {
+///         // ...
+///     }
+///     #[cfg(test)]
+///     pub(super) struct MockFoo {
+///         // ...
+///     }
+/// }
+/// #[double]
+/// use foo::Foo;
+/// ```
+/// That will expand to the following:
+/// ```no_run
+/// # use mockall_double::double;
+/// # mod foo { pub struct Foo {} }
+/// #[cfg(not(test))]
+/// use foo::Foo;
+/// #[cfg(test)]
+/// use foo::MockFoo as Foo;
+/// ```
+/// `#[double]` can handle deeply nested paths,
+/// ```no_run
+/// # use mockall_double::double;
+/// # mod foo { pub mod bar { pub struct Baz{} } }
+/// #[double]
+/// use foo::bar::Baz;
+/// ```
+/// grouped imports,
+/// ```no_run
+/// # mod foo { pub mod bar { pub struct Baz{} pub struct Bean {} } }
+/// # use mockall_double::double;
+/// #[double]
+/// use foo::bar::{
+///     Baz,
+///     Bean
+/// };
+/// ```
+/// and renamed imports, too.  With renamed imports, it isn't even necessary to
+/// declare a submodule.
+/// ```no_run
+/// # use mockall_double::double;
+/// # struct Foo {}
+/// #[double]
+/// use Foo as Bar;
+/// ```
+/// Finally, `#[double]` can also import entire mocked modules, not just
+/// structures.  In this case the naming convention is different.  It will
+/// replace "xxx" with "mock_xxx".  For example:
+/// ```no_run
+/// # use mockall_double::double;
+/// mod foo {
+///     pub mod inner {
+///         // ...
+///     }
+///     pub mod mock_inner {
+///         // ...
+///     }
+/// }
+/// #[double]
+/// use foo::inner;
+/// ```
+/// will expand to:
+/// ```no_run
+/// # use mockall_double::double;
+/// # mod foo { pub mod inner { } pub mod mock_inner { } }
+/// #[cfg(not(test))]
+/// use foo::inner;
+/// #[cfg(test)]
+/// use foo::mock_inner as inner;
+/// ```
+///
+#[proc_macro_attribute]
+pub fn double(attrs: proc_macro::TokenStream, input: proc_macro::TokenStream)
+    -> proc_macro::TokenStream
+{
+    do_double(attrs.into(), input.into()).into()
+}
+
+fn mock_itemuse(orig: &mut ItemUse) {
+    if let UseTree::Name(un) = &orig.tree {
+        compile_error(un.span(),
+            "Cannot double types in the current module.  Use a submodule (use foo::Foo) or a rename (use Foo as Bar)");
+    } else {
+        mock_usetree(&mut orig.tree)
+    }
+}
+
+fn mock_ident(i: &Ident) -> Ident {
+    let is_type = format!("{}", i)
+        .chars()
+        .next()
+        .expect("zero-length ident?")
+        .is_uppercase();
+    if is_type {
+        // probably a Type
+        format_ident!("Mock{}", i)
+    } else {
+        // probably a module
+        format_ident!("mock_{}", i)
+    }
+}
+
+fn mock_usetree(mut orig: &mut UseTree) {
+    match &mut orig {
+        UseTree::Glob(star) => {
+            compile_error(star.span(),
+                "Cannot double glob imports.  Import by fully qualified name instead.");
+        },
+        UseTree::Group(ug) => {
+            for ut in ug.items.iter_mut() {
+                mock_usetree(ut);
+            }
+        },
+        UseTree::Name(un) => {
+            *orig = UseTree::Rename(UseRename {
+                ident: mock_ident(&un.ident),
+                as_token: <Token![as]>::default(),
+                rename: un.ident.clone()
+            });
+        },
+        UseTree::Path(up) => {
+            mock_usetree(up.tree.as_mut());
+        },
+        UseTree::Rename(ur) => {
+            ur.ident = mock_ident(&ur.ident)
+        },
+    }
+}
+
+#[cfg(test)]
+mod t {
+    use super::*;
+
+mod double {
+    use super::*;
+    use std::str::FromStr;
+
+    fn cmp(attrs: &str, code: &str, expected: &str) {
+        let attrs_ts = TokenStream::from_str(attrs).unwrap();
+        let code_ts = TokenStream::from_str(code).unwrap();
+        let output = do_double(attrs_ts, code_ts);
+        let output = output.to_string();
+        // Round-trip expected through proc_macro2 so whitespace will be
+        // identically formatted
+        let expected = TokenStream::from_str(expected)
+            .unwrap()
+            .to_string();
+        assert_eq!(output, expected);
+    }
+
+    #[test]
+    #[should_panic(expected = "Cannot double glob")]
+    fn glob() {
+        let code = r#"use foo::*;"#;
+        cmp("", &code, "");
+    }
+
+    #[test]
+    fn group() {
+        let code = r#"
+            use foo::bar::{
+                Baz,
+                Bean
+            };
+        "#;
+        let expected = r#"
+            #[cfg(not(test))]
+            use foo::bar::{
+                Baz,
+                Bean
+            };
+            #[cfg(test)]
+            use foo::bar::{
+                MockBaz as Baz,
+                MockBean as Bean
+            };
+        "#;
+        cmp("", &code, &expected);
+    }
+
+    #[test]
+    fn module() {
+        let code = r#"use foo::bar;"#;
+        let expected = r#"
+            #[cfg(not(test))]
+            use foo::bar;
+            #[cfg(test)]
+            use foo::mock_bar as bar;
+        "#;
+        cmp("", &code, &expected);
+    }
+
+    #[test]
+    #[should_panic(expected = "Cannot double types in the current module")]
+    fn name() {
+        let code = r#"use Foo;"#;
+        cmp("", &code, "");
+    }
+
+    #[test]
+    fn path() {
+        let code = r#"use foo::bar::Baz;"#;
+        let expected = r#"
+            #[cfg(not(test))]
+            use foo::bar::Baz;
+            #[cfg(test)]
+            use foo::bar::MockBaz as Baz;
+        "#;
+        cmp("", &code, &expected);
+    }
+
+    #[test]
+    fn rename() {
+        let code = r#"use Foo as Bar;"#;
+        let expected = r#"
+            #[cfg(not(test))]
+            use Foo as Bar;
+            #[cfg(test)]
+            use MockFoo as Bar;
+        "#;
+        cmp("", &code, &expected);
+    }
+
+    #[test]
+    fn not_use_stmt() {
+        let code = r#"struct Foo{}"#;
+        cmp("", &code, "compile_error!{\"expected `use`\"}");
+    }
+}
+}
+

--- a/release.toml
+++ b/release.toml
@@ -1,11 +1,3 @@
-dev-version-ext = "pre"
 upload-doc = false
 # Adding a dev version breaks dependencies like {version = "=...", path = "..."}
 no-dev-version = true
-
-# cargo-release can't yet update CHANGELOG.md
-# https://github.com/sunng87/cargo-release/issues/154
-#pre-release-replacements = [
-	#{ file="CHANGELOG.md", search="Unreleased", replace="{{version}}" },
-	#{ file="CHANGELOG.md", search="ReleaseDate", replace="{{date}}" }
-#]


### PR DESCRIPTION
    Add mockall_double, a handy double adapter.
    
    It makes it easier to import Mockall's mocked structs and modules.
    Basically, it replaces cfg-if, and turns 6 lines into 1.
    
    Fixes #71


    Also, improve release procedure
    
    * Automatically update CHANGELOG.md
    * Don't generate tags for mockall_derive
    * Name tags "vX.Y.Z" instead of "mockall-vX.Y.Z"
    * Do fewer git pushes
    
    The procedure for mockall_double is unchanged, because it's expected
    that mockall_double won't have its releases synchronized with the other
    crates.