### PR TITLE
Change mock!'s syntax for traits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased] - ReleaseDate
 ### Added
 
+- `mock!` supports a new syntax: "impl Trait for".  It has two benefits:
+  * It can implement a generic trait for specific generic type(s).
+  * It allows mocking a non-local trait.
+  The syntax looks like this:
+  ```rust
+    mock! {
+        Bar {}
+        impl Foo<i32> for Bar {
+            fn foo(&self, x: i32) -> i32;
+        }
+    }
+  ```
+  ([#205](https://github.com/asomers/mockall/pull/205))
+
 - `#[automock]` now works on modules even without the `nightly` feature, and no
   longer requires `#[feature(proc_macro_hygiene)]`.
   ([#198](https://github.com/asomers/mockall/pull/198))

--- a/mockall/src/lib.rs
+++ b/mockall/src/lib.rs
@@ -743,11 +743,11 @@
 //!     // Structure to mock
 //!     C {}
 //!     // First trait to implement on C
-//!     trait A {
+//!     impl A for C {
 //!         fn foo(&self);
 //!     }
 //!     // Second trait to implement on C
-//!     trait B: A {
+//!     impl B for C {
 //!         fn bar(&self);
 //!     }
 //! }
@@ -770,7 +770,7 @@
 //! # use mockall::*;
 //! mock! {
 //!     MyStruct {}     // Name of the mock struct, less the "Mock" prefix
-//!     trait Clone {   // definition of the trait to mock
+//!     impl Clone for MyStruct {   // specification of the trait to mock
 //!         fn clone(&self) -> Self;
 //!     }
 //! }
@@ -1009,7 +1009,7 @@
 //! mock! {
 //!     pub Bar {}
 //!     #[async_trait]
-//!     trait Foo {
+//!     impl Foo for Bar {
 //!         async fn foo(&self) -> u32;
 //!     }
 //! }
@@ -1201,8 +1201,8 @@ pub use mockall_derive::automock;
 /// * Real structure name and generics fields
 /// * 0 or more methods of the structure, written without bodies, enclosed in a
 ///   {} block
-/// * 0 or more traits to implement for the structure, written like normal
-///   traits
+/// * 0 or more impl blocks implementing traits on the structure, also without
+///   bodies.
 ///
 /// # Examples
 ///
@@ -1216,7 +1216,7 @@ pub use mockall_derive::automock;
 ///     pub MyStruct<T: Clone + 'static> {
 ///         fn bar(&self) -> u8;
 ///     }
-///     trait Foo {
+///     impl Foo for MyStruct {
 ///         fn foo(&self, x: u32);
 ///     }
 /// }
@@ -1230,7 +1230,7 @@ pub use mockall_derive::automock;
 /// # use mockall_derive::mock;
 /// mock!{
 ///     pub Rc<T: 'static> {}
-///     trait AsRef<T> {
+///     impl<T: 'static> AsRef<T> for Rc<T> {
 ///         fn as_ref(&self) -> &T;
 ///     }
 /// }
@@ -1241,7 +1241,7 @@ pub use mockall_derive::automock;
 /// # use mockall_derive::mock;
 /// mock!{
 ///     pub Rc<Q: 'static> {}
-///     trait AsRef<T: 'static> {
+///     impl<T: 'static> AsRef<T> for Rc<T> {
 ///         fn as_ref(&self) -> &T;
 ///     }
 /// }
@@ -1255,7 +1255,7 @@ pub use mockall_derive::automock;
 /// # use mockall_derive::mock;
 /// mock!{
 ///     MyIter {}
-///     trait Iterator {
+///     impl Iterator for MyIter {
 ///         type Item=u32;
 ///
 ///         fn next(&mut self) -> Option<u32>;
@@ -1268,7 +1268,7 @@ pub use mockall_derive::automock;
 /// # use mockall_derive::mock;
 /// mock!{
 ///     MyIter {}
-///     trait Iterator {
+///     impl Iterator for MyIter {
 ///         type Item=u32;
 ///
 ///         fn next(&mut self) -> Option<<Self as Iterator>::Item>;

--- a/mockall/tests/mock_associated_const.rs
+++ b/mockall/tests/mock_associated_const.rs
@@ -19,7 +19,7 @@ mock! {
         const Y: i32 = 69;
         fn foo(&self);
     }
-    trait Foo {
+    impl Foo for Foo {
         const X: i32 = 42;
     }
 }

--- a/mockall/tests/mock_associated_types.rs
+++ b/mockall/tests/mock_associated_types.rs
@@ -5,7 +5,7 @@ use mockall::*;
 
 mock! {
     MyIter {}
-    trait Iterator {
+    impl Iterator for MyIter {
         type Item=u32;
 
         fn next(&mut self) -> Option<u32>;

--- a/mockall/tests/mock_async_trait.rs
+++ b/mockall/tests/mock_async_trait.rs
@@ -14,7 +14,7 @@ pub trait Foo {
 mock! {
     pub Bar { }
     #[async_trait]
-    trait Foo {
+    impl Foo for Bar {
         async fn foo(&self) -> u32;
     }
 }

--- a/mockall/tests/mock_clone.rs
+++ b/mockall/tests/mock_clone.rs
@@ -7,7 +7,7 @@ use mockall::*;
 
 mock! {
     pub A {}
-    trait Clone {
+    impl Clone for A {
         fn clone(&self) -> Self;
     }
 }

--- a/mockall/tests/mock_concrete_struct_with_generic_trait.rs
+++ b/mockall/tests/mock_concrete_struct_with_generic_trait.rs
@@ -1,0 +1,24 @@
+// vim: tw=80
+//! A concrete struct that implements a generic trait
+#![deny(warnings)]
+
+use mockall::*;
+
+trait Foo<T: 'static> {
+    fn foo(&self, x: T) -> T;
+}
+mock! {
+    Bar {}
+    impl Foo<i32> for Bar {
+        fn foo(&self, x: i32) -> i32;
+    }
+}
+
+#[test]
+fn returning() {
+    let mut mock = MockBar::new();
+    mock.expect_foo()
+        .with(predicate::eq(42))
+        .returning(|x| x + 1);
+    assert_eq!(43, mock.foo(42));
+}

--- a/mockall/tests/mock_docs.rs
+++ b/mockall/tests/mock_docs.rs
@@ -19,7 +19,7 @@ mock!{
         fn foo(&self);
     }
     /// Trait docs
-    trait Tr {
+    impl Tr for Foo {
         /// Trait method docs
         fn bar(&self);
     }

--- a/mockall/tests/mock_generic_arguments_returning_reference.rs
+++ b/mockall/tests/mock_generic_arguments_returning_reference.rs
@@ -9,7 +9,7 @@ trait Foo {
 
 mock!{
     MyStruct {}
-    trait Foo {
+    impl Foo for MyStruct {
         fn foo<T: 'static>(&self, t: T) -> &u32;
     }
 }

--- a/mockall/tests/mock_generic_struct_with_generic_trait_oldstyle.rs
+++ b/mockall/tests/mock_generic_struct_with_generic_trait_oldstyle.rs
@@ -1,5 +1,7 @@
 // vim: tw=80
+//! A generic struct with a generic trait, using the <= 0.8.0 syntax
 #![deny(warnings)]
+#![allow(deprecated)]
 
 use mockall::*;
 
@@ -8,7 +10,7 @@ trait Foo<T: 'static> {
 }
 mock! {
     Bar<T: 'static, Z: 'static> {}
-    impl<T: 'static, Z: 'static> Foo<T> for Bar<T, Z> {
+    trait Foo<T: 'static> {
         fn foo(&self, x: T) -> T;
     }
 }

--- a/mockall/tests/mock_generic_struct_with_generic_trait_with_different_bounds.rs
+++ b/mockall/tests/mock_generic_struct_with_generic_trait_with_different_bounds.rs
@@ -8,7 +8,7 @@ trait Foo<T> {
 }
 mock! {
     Bar<T: 'static> {}
-    trait Foo<T> {
+    impl<T: 'static> Foo<T> for Bar {
         fn foo(&self, x: T) -> T;
     }
 }

--- a/mockall/tests/mock_generic_struct_with_nondefault_parameter.rs
+++ b/mockall/tests/mock_generic_struct_with_nondefault_parameter.rs
@@ -12,7 +12,7 @@ trait Foo<T: 'static> {
 }
 mock! {
     ExternalStruct<T: 'static> {}
-    trait Foo<T: 'static> {
+    impl<T: 'static> Foo<T> for ExternalStruct<T> {
         fn foo(&self) -> T;
     }
 }

--- a/mockall/tests/mock_generic_struct_with_trait.rs
+++ b/mockall/tests/mock_generic_struct_with_trait.rs
@@ -9,7 +9,7 @@ trait Foo {
 
 mock! {
     Bar<T: Copy + 'static> {}
-    trait Foo {
+    impl<T: Copy + 'static> Foo for Bar<T> {
         fn foo(&self, x: u32) -> u32;
     }
 }

--- a/mockall/tests/mock_generic_struct_with_trait_with_associated_types.rs
+++ b/mockall/tests/mock_generic_struct_with_trait_with_associated_types.rs
@@ -5,7 +5,7 @@ use mockall::*;
 
 mock! {
     Foo<T: 'static> {}
-    trait Iterator {
+    impl<T: 'static> Iterator for Foo<T> {
         type Item=T;
         fn next(&mut self) -> Option<T>;
     }

--- a/mockall/tests/mock_generic_struct_with_where_clause_and_trait.rs
+++ b/mockall/tests/mock_generic_struct_with_where_clause_and_trait.rs
@@ -14,7 +14,7 @@ mock! {
     Foo<T: 'static> where T: Clone {
         fn foo(&self, t: T) -> T;
     }
-    trait Bar {
+    impl<T: 'static> Bar for Foo<T> where T: Clone {
         fn bar(&self);
     }
 }

--- a/mockall/tests/mock_generic_trait.rs
+++ b/mockall/tests/mock_generic_trait.rs
@@ -9,7 +9,7 @@ trait Foo {
 
 mock! {
     Bar<T: 'static> {}
-    trait Foo {
+    impl<T: 'static> Foo for Bar<T> {
         fn foo(&self);
     }
 }

--- a/mockall/tests/mock_inherited_traits.rs
+++ b/mockall/tests/mock_inherited_traits.rs
@@ -14,10 +14,10 @@ trait B: A {
 
 mock!{
     B {}
-    trait A {
+    impl A for B {
         fn foo(&self);
     }
-    trait B {
+    impl B for B {
         fn bar(&self);
     }
 }

--- a/mockall/tests/mock_multiple_traits.rs
+++ b/mockall/tests/mock_multiple_traits.rs
@@ -8,8 +8,8 @@ trait A {}
 trait B {}
 mock!{
     MultiTrait {}
-    trait A  {}
-    trait B  {}
+    impl A for MultiTrait {}
+    impl B for MultiTrait {}
 }
 
 #[test]

--- a/mockall/tests/mock_nonlocal_trait.rs
+++ b/mockall/tests/mock_nonlocal_trait.rs
@@ -1,0 +1,28 @@
+// vim: tw=80
+//! A trait that isn't imported directly into the local namespace
+#![deny(warnings)]
+
+use mockall::*;
+
+mod my_module {
+    pub trait Foo {
+        fn foo(&self) -> i32;
+    }
+}
+
+mock! {
+    Bar {}
+    impl my_module::Foo for Bar {
+        fn foo(&self) -> i32;
+    }
+}
+
+#[test]
+fn returning() {
+    use my_module::Foo;
+
+    let mut mock = MockBar::new();
+    mock.expect_foo()
+        .returning(|| 42);
+    assert_eq!(42, mock.foo());
+}

--- a/mockall/tests/mock_return_anonymous_lifetime.rs
+++ b/mockall/tests/mock_return_anonymous_lifetime.rs
@@ -17,7 +17,7 @@ mock! {
     Foo {
         fn inherent_method(&self) -> X<'_>;
     }
-    trait T {
+    impl T for Foo {
         fn trait_method(&self) -> X<'_>;
     }
 }

--- a/mockall/tests/mock_struct_with_trait.rs
+++ b/mockall/tests/mock_struct_with_trait.rs
@@ -9,7 +9,7 @@ trait Foo {
 
 mock!{
     pub Bar {}
-    trait Foo {
+    impl Foo for Bar {
         fn foo(&self, x: u32) -> i64;
     }
 }

--- a/mockall/tests/mock_struct_with_trait_with_associated_types.rs
+++ b/mockall/tests/mock_struct_with_trait_with_associated_types.rs
@@ -5,7 +5,7 @@ use mockall::*;
 
 mock! {
     pub MyIter {}
-    trait Iterator {
+    impl Iterator for MyIter {
         type Item=u32;
 
         fn next(&mut self) -> Option<u32>;

--- a/mockall/tests/mock_trait_returning_reference.rs
+++ b/mockall/tests/mock_trait_returning_reference.rs
@@ -10,7 +10,7 @@ trait Foo {
 
 mock! {
     pub Bar {}
-    trait Foo {
+    impl Foo for Bar {
         fn foo(&self) -> &u32;
     }
 }

--- a/mockall/tests/mock_trait_with_static_method.rs
+++ b/mockall/tests/mock_trait_with_static_method.rs
@@ -9,7 +9,7 @@ trait Bar {
 
 mock!{
     pub Foo {}
-    trait Bar {
+    impl Bar for Foo {
         fn baz(x: u32) -> u64;
     }
 }

--- a/mockall_derive/src/mock_item_struct.rs
+++ b/mockall_derive/src/mock_item_struct.rs
@@ -218,7 +218,8 @@ impl ToTokens for MockItemStruct {
                     fieldname: format_ident!("{}_expectations", trait_.name()),
                     methods: Methods(trait_.methods.clone()),
                     modname: format_ident!("{}_{}", &self.modname, trait_.name()),
-                    name: format_ident!("{}_{}", &self.name, trait_.name()),
+                    name: format_ident!("{}_{}", &self.name, trait_.name(),
+                        span = trait_.name().span()),
                 }
             }).collect::<Vec<_>>();
         let substruct_expectations = substructs.iter()

--- a/mockall_derive/src/mock_item_struct.rs
+++ b/mockall_derive/src/mock_item_struct.rs
@@ -148,11 +148,11 @@ impl From<MockableStruct> for MockItemStruct {
         let vis = mockable.vis;
         let has_new = mockable.methods.iter()
             .any(|meth| meth.sig.ident == "new") ||
-            mockable.traits.iter()
-            .any(|trait_|
-                trait_.items.iter()
-                    .any(|ti| if let TraitItem::Method(tim) = ti {
-                            tim.sig.ident == "new"
+            mockable.impls.iter()
+            .any(|impl_|
+                impl_.items.iter()
+                    .any(|ii| if let ImplItem::Method(iim) = ii {
+                            iim.sig.ident == "new"
                         } else {
                             false
                         }
@@ -169,8 +169,8 @@ impl From<MockableStruct> for MockItemStruct {
                     .build()
             ).collect::<Vec<_>>());
         let structname = &mockable.name;
-        let traits = mockable.traits.into_iter()
-            .map(|t| MockTrait::new(structname, &generics, t, &vis))
+        let traits = mockable.impls.into_iter()
+            .map(|i| MockTrait::new(structname, &generics, i, &vis))
             .collect();
 
         MockItemStruct {


### PR DESCRIPTION
    Previously the syntax looked like a trait definition `trait X`.  But
    that's ambiguous in the case of generic traits.  It doesn't make clear
    the relationship between the trait's generic parameters and the struct's
    generic parameters.  And it made it impossible for a concrete struct to
    implement a generic trait.
    
    The new syntax looks like a trait impl `impl X for Y`.  That solves all
    the problems with generics.  In addition, it allows `mock!` to implement
    traits that aren't imported directly into the current namespace
    `impl x::y::Z for Foo`.
    
    The old syntax is deprecated, but will be supported for at least one
    more release.
    
    Fixes #119
