### PR TITLE
`mock!` now requires visibility specifiers for inherent methods.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+- `mock!` now requires visibility specifiers for inherent methods.
+  ([#207](https://github.com/asomers/mockall/pull/207))
+
 - Changed the syntax for mocking foreign functions.  Instead of using
   `#[automock]` directly on the `extern` block, you must wrap the `extern`
   block in a module, and `#[automock]` that module.  The old method is

--- a/mockall_derive/src/mockable_struct.rs
+++ b/mockall_derive/src/mockable_struct.rs
@@ -467,13 +467,13 @@ impl Parse for MockableStruct {
         let mut consts = Vec::new();
         let mut methods = Vec::new();
         while !impl_content.is_empty() {
-            let method: syn::TraitItem = impl_content.parse()?;
-            match method {
-                syn::TraitItem::Method(mut meth) => {
-                    mockable_trait_method(&mut meth, &name, &generics);
-                    methods.push(tim2iim(meth, &vis))
+            let item: ImplItem = impl_content.parse()?;
+            match item {
+                ImplItem::Method(mut iim) => {
+                    mockable_method(&mut iim, &name, &generics);
+                    methods.push(iim);
                 },
-                TraitItem::Const(iic) => consts.push(tic2iic(iic, &vis)),
+                ImplItem::Const(iic) => consts.push(iic),
                 _ => {
                     return Err(input.error("Unsupported in this context"));
                 }


### PR DESCRIPTION
Previously, it forbade them, and treated the inherent method as having
the same visibility as the struct itself.  That was occasionally
problematic, for example when the mock struct was pub but one of its
methods' arguments was not.

Relates to issue #143