### PR TITLE
Delete a weird copypasta from PR #205

### DIFF
--- a/mockall_derive/src/mock_item_struct.rs
+++ b/mockall_derive/src/mock_item_struct.rs
@@ -218,8 +218,7 @@ impl ToTokens for MockItemStruct {
                     fieldname: format_ident!("{}_expectations", trait_.name()),
                     methods: Methods(trait_.methods.clone()),
                     modname: format_ident!("{}_{}", &self.modname, trait_.name()),
-                    name: format_ident!("{}_{}", &self.name, trait_.name(),
-                        span = trait_.name().span()),
+                    name: format_ident!("{}_{}", &self.name, trait_.name()),
                 }
             }).collect::<Vec<_>>();
         let substruct_expectations = substructs.iter()

--- a/mockall_derive/src/mockable_struct.rs
+++ b/mockall_derive/src/mockable_struct.rs
@@ -233,8 +233,6 @@ fn mockable_trait(trait_: ItemTrait, name: &Ident, generics: &Generics)
     let mut path = Path::from(trait_.ident);
     let (_, tg, _) = trait_.generics.split_for_impl();
     if let Ok(abga) = parse2::<AngleBracketedGenericArguments>(quote!(#tg)) {
-        // TODO: delete this ugly hack when we remove the ability to mock traits
-        // with the old syntax
         path.segments.last_mut().unwrap().arguments =
             PathArguments::AngleBracketed(abga);
     }


### PR DESCRIPTION
It's remarkable that the compiler accepts this without complaint.

Also, fix an incorrect comment from the same commit.  The
AngleBracketedGenericArguments will also be present when using automock