### PR TITLE
Don't generic unneeded GenericExpectation code

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -46,6 +46,8 @@ minver_task:
   cargo_cache:
     folder: $CARGO_HOME/registry
   test_script:
+    # Workaround Rust bug https://github.com/rust-lang/rust/issues/78660
+    - env RUSTUP_HOME=/usr/local/rustup CARGO_HOME=/usr/local/cargo PATH=/usr/local/cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin && rustup toolchain install --profile minimal nightly-2020-10-27-x86_64 && rustup default nightly-2020-10-27-x86_64
     - cargo update -Zminimal-versions
     - cargo test --all-features --all
   before_cache_script: rm -rf $CARGO_HOME/registry/index

--- a/mockall_derive/src/mock_function.rs
+++ b/mockall_derive/src/mock_function.rs
@@ -2248,6 +2248,9 @@ impl<'a> ToTokens for GenericExpectations<'a> {
         if ! self.f.is_expectation_generic() {
             return;
         }
+        if ! self.f.is_static() && ! self.f.is_method_generic() {
+            return;
+        }
 
         let ge = StaticGenericExpectations{f: self.f};
         let v = &self.f.privmod_vis;


### PR DESCRIPTION
We had been generating it, but not calling it, for non-generic methods
of generic structs.