### PR TITLE
Allow mocking methods with lifetime parameters of generic structs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased] - ReleaseDate
 ### Added
 
+- Added the ability to mock generic structs with generic methods whose only
+  generic types are lifetimes.  This is useful for mocking generic structs that
+  implement traits like `Future` and `Stream`.
+  ([#226](https://github.com/asomers/mockall/pull/226))
+
 - Added the ability to mock methods returning references to trait objects.
   ([#213](https://github.com/asomers/mockall/pull/213))
 

--- a/mockall/Cargo.toml
+++ b/mockall/Cargo.toml
@@ -34,7 +34,7 @@ mockall_derive = { version = "= 0.8.0", path = "../mockall_derive" }
 
 [dev-dependencies]
 async-trait = "0.1.38"
-futures = "0.3"
+futures = "0.3.7"
 mockall_double = { version = "0.1.0", path = "../mockall_double" }
 serde = "1.0"
 serde_derive = "1.0"

--- a/mockall/tests/automock_generic_future.rs
+++ b/mockall/tests/automock_generic_future.rs
@@ -1,0 +1,36 @@
+// vim: tw=80
+//! A generic mock object that implements Future
+//!
+//! This is tricky because the Context object has a lifetime parameter, yet the
+//! poll method must not be treated as a generic method.
+#![deny(warnings)]
+
+use mockall::*;
+use std::{
+    future::Future,
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+struct Foo<T: 'static>(T);
+
+#[automock]
+impl<T: 'static> Future for Foo<T> {
+    type Output = ();
+
+    fn poll<'a>(self: Pin<&mut Self>, _cx: &mut Context<'a>)
+        -> Poll<Self::Output>
+    {
+        unimplemented!()
+    }
+}
+
+#[test]
+fn ready() {
+    let mut mock = MockFoo::<u32>::new();
+    mock.expect_poll()
+        .return_const(Poll::Ready(()));
+    let _r = async {
+        mock.await
+    };
+}

--- a/mockall/tests/automock_generic_future_with_where_clause.rs
+++ b/mockall/tests/automock_generic_future_with_where_clause.rs
@@ -1,0 +1,35 @@
+// vim: tw=80
+//! A generic mock object with a method that has only lifetime generic
+//! parameters, and a where clause that bounds a generic type not used by the
+//! method.
+//!
+//! Mockall must not emit the where clause for the method's Expectation.
+#![deny(warnings)]
+
+use mockall::*;
+//use std::task::Context;
+
+struct Foo<T: 'static, V: 'static>((T, V));
+trait MyTrait {
+    type Item;
+
+    fn myfunc(&self, cx: &NonStatic) -> Self::Item;
+}
+pub struct NonStatic<'ns>(&'ns i32);
+
+#[automock]
+impl<T: 'static, V: 'static> MyTrait for Foo<T, V> where T: Clone {
+    type Item = V;
+
+    fn myfunc<'a>(&self, _cx: &NonStatic<'a>) -> V { unimplemented!() }
+}
+
+#[test]
+fn return_const() {
+    let mut mock = MockFoo::<u32, u32>::new();
+    let x = 5i32;
+    let ns = NonStatic(&x);
+    mock.expect_myfunc()
+        .return_const(42u32);
+    assert_eq!(42u32, mock.myfunc(&ns));
+}

--- a/mockall_derive/src/lib.rs
+++ b/mockall_derive/src/lib.rs
@@ -508,10 +508,101 @@ fn find_lifetimes(ty: &Type) -> HashSet<Lifetime> {
             compile_error(ty.span(), "unsupported type in this context");
             HashSet::default()
         }
-
     }
 }
 
+fn find_type_idents_in_tpb(bound: &TypeParamBound) -> HashSet<Ident> {
+    let mut ret = HashSet::default();
+    if let TypeParamBound::Trait(tb) = bound {
+        ret.extend(find_type_idents_in_path(&tb.path));
+    };
+    ret
+}
+
+fn find_type_idents_in_path(path: &Path) -> HashSet<Ident> {
+    let mut ret = HashSet::default();
+    for seg in path.segments.iter() {
+        ret.insert(seg.ident.clone());
+        if let PathArguments::AngleBracketed(abga) = &seg.arguments {
+            for arg in abga.args.iter() {
+                match arg {
+                    GenericArgument::Lifetime(_) => (),
+                    GenericArgument::Type(ty) => {
+                        ret.extend(find_type_idents(&ty));
+                    },
+                    GenericArgument::Binding(b) => {
+                        ret.insert(b.ident.clone());
+                        ret.extend(find_type_idents(&b.ty));
+                    },
+                    GenericArgument::Constraint(c) => {
+                        for bound in c.bounds.iter() {
+                            ret.extend(find_type_idents_in_tpb(bound));
+                        }
+                    },
+                    GenericArgument::Const(_) => ()
+                }
+            }
+        }
+    }
+    ret
+}
+
+/// Find all idents, excluding lifetimes, that appear in the argument
+fn find_type_idents(ty: &Type) -> HashSet<Ident> {
+    match ty {
+        Type::Array(ta) => find_type_idents(ta.elem.as_ref()),
+        Type::BareFn(tbf) => {
+            let mut ret = HashSet::default();
+            for arg in tbf.inputs.iter() {
+                ret.extend(find_type_idents(&arg.ty));
+            }
+            if let ReturnType::Type(_, ty) = &tbf.output {
+                ret.extend(find_type_idents(ty.as_ref()));
+            }
+            ret
+        },
+        Type::Group(tg) => find_type_idents(tg.elem.as_ref()),
+        Type::ImplTrait(tit) => {
+            let mut ret = HashSet::default();
+            for tpb in tit.bounds.iter() {
+                ret.extend(find_type_idents_in_tpb(tpb));
+            }
+            ret
+        },
+        Type::Infer(_ti) => HashSet::default(),
+        Type::Never(_tn) => HashSet::default(),
+        Type::Paren(tp) => find_type_idents(tp.elem.as_ref()),
+        Type::Path(tp) => {
+            let mut ret = find_type_idents_in_path(&tp.path);
+            if let Some(qs) = &tp.qself {
+                ret.extend(find_type_idents(qs.ty.as_ref()));
+            }
+            ret
+        },
+        Type::Ptr(tp) => find_type_idents(tp.elem.as_ref()),
+        Type::Reference(tr) => find_type_idents(tr.elem.as_ref()),
+        Type::Slice(ts) => find_type_idents(ts.elem.as_ref()),
+        Type::TraitObject(tto) => {
+            let mut ret = HashSet::default();
+            for bound in tto.bounds.iter() {
+                ret.extend(find_type_idents_in_tpb(bound));
+            }
+            ret
+        }
+        Type::Tuple(tt) => {
+            let mut ret = HashSet::default();
+            for ty in tt.elems.iter() {
+                ret.extend(find_type_idents(ty));
+            }
+            ret
+        },
+        _ => {
+            compile_error(ty.span(), "unsupported type in this context");
+            HashSet::default()
+        }
+
+    }
+}
 
 struct AttrFormatter<'a>{
     attrs: &'a [Attribute],
@@ -857,8 +948,10 @@ fn split_lifetimes(
         return (generics, Default::default(), Default::default());
     }
 
-    // Check which lifetimes are referenced by the arguments
+    // Check which types and lifetimes are referenced by the arguments
     let mut alts = HashSet::<Lifetime>::default();
+    let mut rlts = HashSet::<Lifetime>::default();
+    let mut types = HashSet::<Ident>::default();
     for arg in args {
         match arg {
             FnArg::Receiver(r) => {
@@ -869,16 +962,16 @@ fn split_lifetimes(
                 }
             },
             FnArg::Typed(pt) => {
-                alts.extend(find_lifetimes(pt.ty.as_ref()))
+                alts.extend(find_lifetimes(pt.ty.as_ref()));
+                types.extend(find_type_idents(pt.ty.as_ref()));
             },
         };
     };
 
-    // Check which lifetimes are referenced by the return type
-    let rlts = match rt {
-        ReturnType::Default => HashSet::default(),
-        ReturnType::Type(_, ty) => find_lifetimes(ty)
-    };
+    if let ReturnType::Type(_, ty) = rt {
+        rlts.extend(find_lifetimes(ty));
+        types.extend(find_type_idents(ty));
+    }
 
     let mut tv = Vec::new();
     let mut alv = Punctuated::new();
@@ -893,7 +986,8 @@ fn split_lifetimes(
                 // Probably a lifetime parameter from the impl block that isn't
                 // used by this particular method
             },
-            _ => tv.push(p)
+            GenericParam::Type(tp) if types.contains(&tp.ident) => tv.push(p),
+            _ => (),
         }
     }
 

--- a/mockall_derive/src/mock_function.rs
+++ b/mockall_derive/src/mock_function.rs
@@ -1334,7 +1334,6 @@ impl<'a> ToTokens for GenericExpectationGuard<'a> {
         egenerics.params.push(GenericParam::Lifetime(ltdef));
         egenerics.gt_token.get_or_insert(<Token![>]>::default());
         let (e_ig, e_tg, e_wc) = egenerics.split_for_impl();
-        let (ei_ig, _, _) = egenerics.split_for_impl();
         let fn_params = &self.f.fn_params;
         let tbf = tg.as_turbofish();
         let v = &self.f.privmod_vis;
@@ -1354,7 +1353,7 @@ impl<'a> ToTokens for GenericExpectationGuard<'a> {
             }
 
             #[allow(clippy::unused_unit)]
-            impl #ei_ig ExpectationGuard #e_tg #e_wc
+            impl #e_ig ExpectationGuard #e_tg #e_wc
             {
                 // Should only be called from the mockall_derive generated
                 // code


### PR DESCRIPTION
For example, generic structs implementing Future.  The method must not be treated as a generic method, since it has a non-static argument.
    
Issue #223