### PR TITLE
Revert most of PR #226

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,6 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased] - ReleaseDate
 ### Added
 
-- Added the ability to mock generic structs with generic methods whose only
-  generic types are lifetimes.  This is useful for mocking generic structs that
-  implement traits like `Future` and `Stream`.
-  ([#226](https://github.com/asomers/mockall/pull/226))
-
 - Added the ability to mock methods returning references to trait objects.
   ([#213](https://github.com/asomers/mockall/pull/213))
 
@@ -44,6 +39,14 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   ([#201](https://github.com/asomers/mockall/pull/201))
 
 ### Fixed
+
+- Fixed mocking generic structs with generic methods whose only generic types
+  are lifetimes.  This is useful for mocking generic structs that implement
+  traits like `Future` and `Stream`.
+  ([#225](https://github.com/asomers/mockall/pull/225))
+  ([#226](https://github.com/asomers/mockall/pull/226))
+  ([#228](https://github.com/asomers/mockall/pull/228))
+
 ### Removed
 
 - Removed `times_any` and `times_range` methods from Expectations.  They've


### PR DESCRIPTION
It turns out that it wasn't necessary.  PR #225 was sufficient to fix the issue.  And #226 is awkward, because it can result in the expect_ methods having fewer generic parameters than the original methods. Worse, sometimes mockall will generate code that fails to compile, because the Where clauses reference generic parameters that aren't there.
