### PR TITLE
Automock methods returning "impl Future"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased] - ReleaseDate
 ### Added
 
+- Added the ability to mock methods returning `impl Future` or `impl Stream`.
+  Unlike other traits, these two aren't very useful in a `Box`.  Instead,
+  Mockall will now change the Expectation's return type to `Pin<Box<_>>`.
+  ([#229](https://github.com/asomers/mockall/pull/229))
+
 - Added the ability to mock methods returning references to trait objects.
   ([#213](https://github.com/asomers/mockall/pull/213))
 

--- a/mockall/src/lib.rs
+++ b/mockall/src/lib.rs
@@ -595,6 +595,34 @@
 //!
 //! See Also [`impl-trait-for-returning-complex-types-with-ease.html`](https://rust-lang-nursery.github.io/edition-guide/rust-2018/trait-system/impl-trait-for-returning-complex-types-with-ease)
 //!
+//! ### impl Future
+//!
+//! Rust 1.36.0 added the `Future` trait.  Unlike virtually every trait that
+//! preceeded it, `Box<dyn Future>` is mostly useless.  Instead, you usually
+//! need a `Pin<Box<dyn Future>>`.  So that's what Mockall will do when you mock
+//! a method returning `impl Future` or the related `impl Stream`.  Just
+//! remember to use `pin` in your expectations, like this:
+//!
+//! ```
+//! # use mockall::*;
+//! # use std::fmt::Debug;
+//! # use futures::{Future, future};
+//! struct Foo {}
+//! #[automock]
+//! impl Foo {
+//!     fn foo(&self) -> impl Future<Output=i32> {
+//!         // ...
+//!         # future::ready(42)
+//!     }
+//! }
+//!
+//! # fn main() {
+//! let mut mock = MockFoo::new();
+//! mock.expect_foo()
+//!     .returning(|| Box::pin(future::ready(42)));
+//! # }
+//! ```
+//!
 //! ## Mocking structs
 //!
 //! Mockall mocks structs as well as traits.  The problem here is a namespace

--- a/mockall/tests/automock_associated_type_constructor.rs
+++ b/mockall/tests/automock_associated_type_constructor.rs
@@ -5,9 +5,8 @@
 
 use mockall::*;
 
-pub trait Future {
+pub trait MyIterator {
     type Item;
-    type Error;
 }
 
 #[allow(unused)]
@@ -15,11 +14,10 @@ pub struct Foo{}
 
 #[automock]
 impl Foo {
-    pub fn open() -> impl Future<Item=Self, Error=i32> {
+    pub fn open() -> impl MyIterator<Item=Self> {
         struct Bar {}
-        impl Future for Bar {
+        impl MyIterator for Bar {
             type Item=Foo;
-            type Error=i32;
         }
         Bar{}
     }
@@ -30,9 +28,8 @@ fn returning() {
     let ctx = MockFoo::open_context();
     ctx.expect().returning(|| {
         struct Baz {}
-        impl Future for Baz {
-            type Item=MockFoo;
-            type Error=i32;
+        impl MyIterator for Baz {
+            type Item = MockFoo;
         }
         Box::new(Baz{})
     });

--- a/mockall/tests/automock_impl_future.rs
+++ b/mockall/tests/automock_impl_future.rs
@@ -1,0 +1,50 @@
+// vim: tw=80
+//! A trait with a constructor method that returns impl Future<...>.
+//!
+//! This needs special handling, because Box<dyn Future<...>> is pretty useless.
+//! You need Pin<Box<dyn Future<...>>> instead.
+#![deny(warnings)]
+
+use futures::{Future, FutureExt, Stream, StreamExt, future, stream};
+use mockall::*;
+
+pub struct Foo{}
+
+#[automock]
+impl Foo {
+    pub fn foo(&self) -> impl Future<Output=u32>
+    {
+        future::ready(42)
+    }
+
+    pub fn bar(&self) -> impl Stream<Item=u32>
+    {
+        stream::empty()
+    }
+}
+
+#[test]
+fn returning_future() {
+    let mut mock = MockFoo::new();
+    mock.expect_foo()
+        .returning(|| {
+            Box::pin(future::ready(42))
+        });
+    mock.foo()
+        .now_or_never()
+        .unwrap();
+}
+
+#[test]
+fn returning_stream() {
+    let mut mock = MockFoo::new();
+    mock.expect_bar()
+        .returning(|| {
+            Box::pin(stream::iter(vec![42].into_iter()))
+        });
+    let all = mock.bar()
+        .collect::<Vec<u32>>()
+        .now_or_never()
+        .unwrap();
+    assert_eq!(&all[..], &[42][..]);
+}


### PR DESCRIPTION
Unlike other traits, these two aren't very useful in a `Box`.  Instead,
Mockall will now change the Expectation's return type to `Pin<Box<_>>`.

Fixes #220