### PR TITLE
Print better messages for "No matching expectation found"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased] - ReleaseDate
+### Added
+
+- When a test fails because a mock object receives an unexpected call, the
+  error message will now show the method's arguments.  This requires the
+  `nightly` feature, and requires that the arguments implement `Debug`.
+  ([#246](https://github.com/asomers/mockall/pull/246))
+
+### Changed
+### Fixed
+### Removed
+
 ## [0.9.0] - 2020-12-21
 ### Added
 

--- a/mockall/src/lib.rs
+++ b/mockall/src/lib.rs
@@ -1114,6 +1114,7 @@
 use downcast::*;
 use std::{
     any,
+    fmt::{self, Debug, Formatter},
     marker::PhantomData,
     ops::{Range, RangeFrom, RangeFull, RangeInclusive, RangeTo,
           RangeToInclusive},
@@ -1353,6 +1354,31 @@ pub struct DefaultReturner<O>(PhantomData<O>);
 
             fn return_default() -> Result<O, &'static str> {
                 Err("Returning default values requires the \"nightly\" feature")
+            }
+        }
+    }
+}
+
+#[doc(hidden)]
+pub struct MaybeDebugger<'a, T>(pub &'a T);
+::cfg_if::cfg_if! {
+    if #[cfg(feature = "nightly")] {
+        impl<'a, T> Debug for MaybeDebugger<'a, T> {
+            default fn fmt(&self, f: &mut Formatter<'_>)
+                -> Result<(), fmt::Error>
+            {
+                write!(f, "?")
+            }
+        }
+        impl<'a, T: Debug> Debug for MaybeDebugger<'a, T> {
+            fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), fmt::Error> {
+                self.0.fmt(f)
+            }
+        }
+    } else {
+        impl<'a, T> Debug for MaybeDebugger<'a, T> {
+            fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), fmt::Error> {
+                write!(f, "?")
             }
         }
     }

--- a/mockall/tests/automock_foreign_c.rs
+++ b/mockall/tests/automock_foreign_c.rs
@@ -23,7 +23,12 @@ fn normal_usage() {
 }
 
 #[test]
-#[should_panic(expected = "mock_ffi::foo1: No matching expectation found")]
+#[cfg_attr(feature = "nightly", should_panic(
+        expected = "mock_ffi::foo1(5): No matching expectation found"
+))]
+#[cfg_attr(not(feature = "nightly"), should_panic(
+        expected = "mock_ffi::foo1(?): No matching expectation found"
+))]
 fn with_no_matches() {
     let ctx = mock_ffi::foo1_context();
     ctx.expect()

--- a/mockall/tests/automock_foreign_extern.rs
+++ b/mockall/tests/automock_foreign_extern.rs
@@ -16,7 +16,12 @@ extern "C" {
 }
 
 #[test]
-#[should_panic(expected = "mock_ffi::foo1: No matching expectation found")]
+#[cfg_attr(feature = "nightly", should_panic(
+        expected = "mock_ffi::foo1(5): No matching expectation found"
+))]
+#[cfg_attr(not(feature = "nightly"), should_panic(
+        expected = "mock_ffi::foo1(?): No matching expectation found"
+))]
 fn with_no_matches() {
     let ctx = mock_ffi::foo1_context();
     ctx.expect()

--- a/mockall/tests/automock_module.rs
+++ b/mockall/tests/automock_module.rs
@@ -20,7 +20,12 @@ mod m {
     }
 
     #[test]
-    #[should_panic(expected = "mock_foo::bar1: No matching expectation found")]
+    #[cfg_attr(feature = "nightly", should_panic(
+            expected = "mock_foo::bar1(5): No matching expectation found"
+    ))]
+    #[cfg_attr(not(feature = "nightly"), should_panic(
+            expected = "mock_foo::bar1(?): No matching expectation found"
+    ))]
     fn with_no_matches() {
         let ctx = mock_foo::bar1_context();
         ctx.expect()

--- a/mockall/tests/automock_nondebug.rs
+++ b/mockall/tests/automock_nondebug.rs
@@ -1,0 +1,27 @@
+// vim: tw=80
+//! A method may have non-Debug arguments and/or return values.
+#![deny(warnings)]
+
+use mockall::*;
+
+// Don't derive Debug
+pub struct NonDebug(u32);
+
+#[automock]
+pub trait Foo {
+    fn foo(&self, x: NonDebug);
+}
+
+#[test]
+#[cfg_attr(feature = "nightly", should_panic(
+        expected = "MockFoo::foo(?): No matching expectation found"
+))]
+#[cfg_attr(not(feature = "nightly"), should_panic(
+        expected = "MockFoo::foo(?): No matching expectation found"
+))]
+fn with_no_matches() {
+    let mock = MockFoo::new();
+    mock.foo(NonDebug(5));
+}
+
+

--- a/mockall/tests/automock_slice_arguments.rs
+++ b/mockall/tests/automock_slice_arguments.rs
@@ -13,7 +13,12 @@ mod withf {
     use super::*;
 
     #[test]
-    #[should_panic(expected = "MockFoo::foo: No matching expectation found")]
+    #[cfg_attr(feature = "nightly", should_panic(
+            expected = "MockFoo::foo([1, 2, 3, 4]): No matching expectation found"
+    ))]
+    #[cfg_attr(not(feature = "nightly"), should_panic(
+            expected = "MockFoo::foo(?): No matching expectation found"
+    ))]
     fn fail() {
         let mut mock = MockFoo::new();
         mock.expect_foo()

--- a/mockall/tests/mock_generic_arguments.rs
+++ b/mockall/tests/mock_generic_arguments.rs
@@ -47,7 +47,12 @@ mod with {
     }
 
     #[test]
-    #[should_panic(expected = "MockFoo::foo: No matching expectation found")]
+    #[cfg_attr(feature = "nightly", should_panic(
+            expected = "MockFoo::foo(4): No matching expectation found"
+    ))]
+    #[cfg_attr(not(feature = "nightly"), should_panic(
+            expected = "MockFoo::foo(?): No matching expectation found"
+    ))]
     fn wrong_generic_type() {
         let mut mock = MockFoo::new();
         mock.expect_foo::<i16>()

--- a/mockall/tests/mock_generic_struct_with_generic_static_method.rs
+++ b/mockall/tests/mock_generic_struct_with_generic_static_method.rs
@@ -48,7 +48,12 @@ fn ctx_checkpoint() {
 
 // Expectations should be cleared when a context object drops
 #[test]
-#[should_panic(expected = "MockFoo::foo3: No matching expectation found")]
+#[cfg_attr(feature = "nightly", should_panic(
+        expected = "MockFoo::foo3(42, 69): No matching expectation found"
+))]
+#[cfg_attr(not(feature = "nightly"), should_panic(
+        expected = "MockFoo::foo3(?, ?): No matching expectation found"
+))]
 fn ctx_hygiene() {
     {
         let ctx0 = MockFoo::<u32>::foo3_context();

--- a/mockall/tests/mock_struct.rs
+++ b/mockall/tests/mock_struct.rs
@@ -64,7 +64,12 @@ mod checkpoint {
     }
 
     #[test]
-    #[should_panic(expected = "MockFoo::foo: No matching expectation found")]
+    #[cfg_attr(feature = "nightly", should_panic(
+            expected = "MockFoo::foo(0): No matching expectation found"
+    ))]
+    #[cfg_attr(not(feature = "nightly"), should_panic(
+            expected = "MockFoo::foo(?): No matching expectation found"
+    ))]
     fn removes_old_expectations() {
         let mut mock = MockFoo::new();
         mock.expect_foo()
@@ -118,7 +123,12 @@ mod r#match {
     }
 
     #[test]
-    #[should_panic(expected = "MockFoo::bar: No matching expectation found")]
+    #[cfg_attr(feature = "nightly", should_panic(
+            expected = "MockFoo::bar(5): No matching expectation found"
+    ))]
+    #[cfg_attr(not(feature = "nightly"), should_panic(
+            expected = "MockFoo::bar(?): No matching expectation found"
+    ))]
     fn with_no_matches() {
         let mut mock = MockFoo::new();
         mock.expect_bar()
@@ -146,7 +156,12 @@ mod r#match {
     }
 
     #[test]
-    #[should_panic(expected = "MockFoo::bar: No matching expectation found")]
+    #[cfg_attr(feature = "nightly", should_panic(
+            expected = "MockFoo::bar(5): No matching expectation found"
+    ))]
+    #[cfg_attr(not(feature = "nightly"), should_panic(
+            expected = "MockFoo::bar(?): No matching expectation found"
+    ))]
     fn withf_no_matches() {
         let mut mock = MockFoo::new();
         mock.expect_bar()

--- a/mockall/tests/mock_struct_with_static_method.rs
+++ b/mockall/tests/mock_struct_with_static_method.rs
@@ -46,7 +46,12 @@ fn ctx_checkpoint() {
 
 // Expectations should be cleared when a context object drops
 #[test]
-#[should_panic(expected = "MockFoo::bar3: No matching expectation found")]
+#[cfg_attr(feature = "nightly", should_panic(
+        expected = "MockFoo::bar3(42): No matching expectation found"
+))]
+#[cfg_attr(not(feature = "nightly"), should_panic(
+        expected = "MockFoo::bar3(?): No matching expectation found"
+))]
 fn ctx_hygiene() {
     {
         let ctx0 = MockFoo::bar3_context();

--- a/mockall/tests/mock_unsized.rs
+++ b/mockall/tests/mock_unsized.rs
@@ -31,7 +31,12 @@ fn with_eq() {
 }
 
 #[test]
-#[should_panic(expected = "MockFoo::foo: No matching expectation found")]
+#[cfg_attr(feature = "nightly", should_panic(
+        expected = "MockFoo::foo(\"xxx\"): No matching expectation found"
+))]
+#[cfg_attr(not(feature = "nightly"), should_panic(
+        expected = "MockFoo::foo(?): No matching expectation found"
+))]
 fn with_never() {
     let mut foo = MockFoo::new();
     foo.expect_foo()


### PR DESCRIPTION
When a method call has no matching expectation, it will now
print the arguments, if they implement Debug.  This requires the
"nightly" crate feature.