### PR TITLE
Better error messages for Sequence violations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased] - ReleaseDate
 ### Added
 
+- When a test fails because of a method sequence violation, the error message
+  will now show the method's arguments.  This requires the `nightly` feature,
+  and requires that the arguments implement `Debug`.
+  ([#247](https://github.com/asomers/mockall/pull/247))
+
 - When a test fails because a mock object receives an unexpected call, the
   error message will now show the method's arguments.  This requires the
   `nightly` feature, and requires that the arguments implement `Debug`.

--- a/mockall/src/lib.rs
+++ b/mockall/src/lib.rs
@@ -1534,8 +1534,8 @@ impl SeqHandle {
     }
 
     /// Verify that this handle was called in the correct order
-    pub fn verify(&self) {
-        self.inner.verify(self.seq);
+    pub fn verify(&self, desc: &str) {
+        self.inner.verify(self.seq, desc);
     }
 }
 
@@ -1552,9 +1552,9 @@ impl SeqInner {
     }
 
     /// Verify that the call identified by `seq` was called in the correct order
-    fn verify(&self, seq: usize) {
+    fn verify(&self, seq: usize, desc: &str) {
         assert_eq!(seq, self.satisfaction_level.load(Ordering::Relaxed),
-            "Method sequence violation")
+            "{}: Method sequence violation", desc)
     }
 }
 

--- a/mockall/tests/mock_return_mutable_reference.rs
+++ b/mockall/tests/mock_return_mutable_reference.rs
@@ -42,3 +42,51 @@ fn returning() {
     let r = mock.foo(0);
     assert_eq!(5, *r);
 }
+
+mod sequence {
+    use super::*;
+
+    #[test]
+    #[cfg_attr(feature = "nightly",
+        should_panic(expected = "MockFoo::foo(4): Method sequence violation"))]
+    #[cfg_attr(not(feature = "nightly"),
+        should_panic(expected = "MockFoo::foo(?): Method sequence violation"))]
+    fn fail() {
+        let mut seq = Sequence::new();
+        let mut mock = MockFoo::new();
+        mock.expect_foo()
+            .with(predicate::eq(3))
+            .times(1)
+            .return_var(0)
+            .in_sequence(&mut seq);
+
+        mock.expect_foo()
+            .with(predicate::eq(4))
+            .times(1)
+            .return_var(0)
+            .in_sequence(&mut seq);
+
+        mock.foo(4);
+    }
+
+    #[test]
+    fn ok() {
+        let mut seq = Sequence::new();
+        let mut mock = MockFoo::new();
+        mock.expect_foo()
+            .with(predicate::eq(3))
+            .times(1)
+            .return_var(0)
+            .in_sequence(&mut seq);
+
+        mock.expect_foo()
+            .with(predicate::eq(4))
+            .times(1)
+            .return_var(0)
+            .in_sequence(&mut seq);
+
+        mock.foo(3);
+        mock.foo(4);
+    }
+
+}

--- a/mockall/tests/mock_return_reference.rs
+++ b/mockall/tests/mock_return_reference.rs
@@ -6,7 +6,7 @@ use mockall::*;
 
 mock! {
     Foo {
-        fn foo(&self) -> &u32;
+        fn foo(&self, x: i32) -> &u32;
         fn bar(&self) -> &u32;
     }
 }
@@ -38,7 +38,7 @@ fn return_const() {
     let mut mock = MockFoo::new();
     mock.expect_foo()
         .return_const(5u32);
-    assert_eq!(5, *mock.foo());
+    assert_eq!(5, *mock.foo(4));
 }
 
 #[test]
@@ -48,7 +48,7 @@ fn return_const() {
 fn return_default() {
     let mut mock = MockFoo::new();
     mock.expect_foo();
-    let r = mock.foo();
+    let r = mock.foo(4);
     assert_eq!(u32::default(), *r);
 }
 
@@ -63,11 +63,14 @@ mod sequence {
         mock.expect_foo()
             .times(1..3)
             .in_sequence(&mut seq);
-        mock.foo();
+        mock.foo(4);
     }
 
     #[test]
-    #[should_panic(expected = "Method sequence violation")]
+    #[cfg_attr(feature = "nightly",
+        should_panic(expected = "MockFoo::foo(4): Method sequence violation"))]
+    #[cfg_attr(not(feature = "nightly"),
+        should_panic(expected = "MockFoo::foo(?): Method sequence violation"))]
     fn fail() {
         let mut seq = Sequence::new();
         let mut mock = MockFoo::new();
@@ -81,7 +84,7 @@ mod sequence {
             .return_const(0)
             .in_sequence(&mut seq);
 
-        mock.foo();
+        mock.foo(4);
         mock.bar();
     }
 
@@ -99,7 +102,7 @@ mod sequence {
             .return_const(0)
             .in_sequence(&mut seq);
 
-        mock.foo();
+        mock.foo(4);
         mock.bar();
     }
 }

--- a/mockall/tests/mock_struct.rs
+++ b/mockall/tests/mock_struct.rs
@@ -236,7 +236,7 @@ mod sequence {
     }
 
     #[test]
-    #[should_panic(expected = "Method sequence violation")]
+    #[should_panic(expected = "MockFoo::baz(): Method sequence violation")]
     fn fail() {
         let mut seq = Sequence::new();
         let mut mock = MockFoo::new();


### PR DESCRIPTION
Print the method name and argument values during a method sequence
violation.  Argument values require the "nightly" feature, and the
arguments must implement Debug.

Fixes #241