### PR TITLE
Fix setting expectations on barely-generic functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [ Unreleased ] - ReleaseDate
+### Fixed
+
+- Fixed setting simultaneous expectations with different generic types on
+  generic methods whose generic parameters appear in neither the arguments nor
+  the return type.
+  ([#272](https://github.com/asomers/mockall/pull/272))
+
 ## [0.9.1] - 2021-02-13
 ### Added
 

--- a/mockall/tests/automock_generic_method_without_generic_args_or_return.rs
+++ b/mockall/tests/automock_generic_method_without_generic_args_or_return.rs
@@ -1,0 +1,42 @@
+// vim: tw=80
+//! generic methods whose generic parameters appear in neither inputs nor return
+//! types should still be mockable, and it should be possible to set
+//! simultaneous expectations for different generic types on the same object.
+#![deny(warnings)]
+
+use mockall::*;
+
+pub struct Foo{}
+
+#[automock]
+impl Foo {
+    pub fn foo<T: 'static>(&self) -> i32 {
+        unimplemented!()
+    }
+    /// A static method
+    pub fn bar<T: 'static>() -> i32 {
+        unimplemented!()
+    }
+}
+
+#[test]
+fn return_const() {
+    let mut mock = MockFoo::new();
+    mock.expect_foo::<f32>()
+        .return_const(42);
+    mock.expect_foo::<f64>()
+        .return_const(69);
+    assert_eq!(42, mock.foo::<f32>());
+    assert_eq!(69, mock.foo::<f64>());
+}
+
+#[test]
+fn static_method() {
+    let ctx = MockFoo::bar_context();
+    ctx.expect::<f32>()
+        .return_const(42);
+    ctx.expect::<f64>()
+        .return_const(69);
+    assert_eq!(42, MockFoo::bar::<f32>());
+    assert_eq!(69, MockFoo::bar::<f64>());
+}

--- a/mockall/tests/mock_closure.rs
+++ b/mockall/tests/mock_closure.rs
@@ -84,6 +84,6 @@ mod returning {
         let mut mock = MockFoo::new();
         mock.expect_foody()
             .returning(|f, _g: u32| f(42));
-        assert_eq!(84, mock.foody(|x| 2 * x, 0));
+        assert_eq!(84, mock.foody(|x| 2u32 * x, 0u32));
     }
 }

--- a/mockall_derive/src/lib.rs
+++ b/mockall_derive/src/lib.rs
@@ -191,6 +191,9 @@ fn declosurefy(gen: &Generics, args: &Punctuated<FnArg, Token![,]>) ->
                 true
             }
         }).cloned());
+        if wc.predicates.is_empty() {
+            wc2 = None;
+        }
     }
     let outg = Generics {
         lt_token: if params.is_empty() { None } else { gen.lt_token },


### PR DESCRIPTION
    If the function's generic parameters appeared in neither input nor
    return type, the Expectations object would not be parameterized on the
    functions generic parameters.  This wasn't really by design; it was
    actually an artifact of Mockall's second incarnation, which used a
    macro_rules! macro to generate the mock objects.
    
    Fixing the problem is easy.  It's a matter of removing the code that
    tried to guess the generic parameters based on the functions arguments
    and return types.
    
    Fixes #269