### PR TITLE
Use a less-predictable name for trait impls structs in generated code

### DIFF
--- a/mockall/tests/mock_same_trait_twice_on_generic_struct.rs
+++ b/mockall/tests/mock_same_trait_twice_on_generic_struct.rs
@@ -1,0 +1,32 @@
+// vim: ts=80
+//! Mock the same generic trait twice on a single struct (with different generic
+//! arguments, of course).
+//!
+#![deny(warnings)]
+#![allow(clippy::from_over_into)]
+
+use mockall::*;
+
+mock! {
+    pub Foo<T: 'static> {}
+    impl Into<u32> for Foo<u32> {
+        fn into(self) -> u32;
+    }
+    impl Into<i32> for Foo<i32> {
+        fn into(self) -> i32;
+    }
+}
+
+/// Ensure we can set expectations for both methods simultaneously
+#[test]
+fn return_once() {
+    let mut mocku = MockFoo::<u32>::new();
+    mocku.expect_into()
+        .return_once(|| 42);
+    let mut mocki = MockFoo::<i32>::new();
+    mocki.expect_into()
+        .return_once(|| -42);
+
+    assert_eq!(<MockFoo<u32> as Into<u32>>::into(mocku), 42u32);
+    assert_eq!(<MockFoo<i32> as Into<i32>>::into(mocki), -42);
+}

--- a/mockall_derive/src/mock_item_struct.rs
+++ b/mockall_derive/src/mock_item_struct.rs
@@ -232,10 +232,12 @@ impl ToTokens for MockItemStruct {
                 MockItemTraitImpl {
                     attrs: trait_.attrs.clone(),
                     generics: self.generics.clone(),
-                    fieldname: format_ident!("{}_expectations", trait_.name()),
+                    fieldname: format_ident!("{}_expectations",
+                                             trait_.ss_name()),
                     methods: Methods(trait_.methods.clone()),
-                    modname: format_ident!("{}_{}", &self.modname, trait_.name()),
-                    name: format_ident!("{}_{}", &self.name, trait_.name()),
+                    modname: format_ident!("{}_{}", &self.modname,
+                                           trait_.ss_name()),
+                    name: format_ident!("{}_{}", &self.name, trait_.ss_name()),
                 }
             }).collect::<Vec<_>>();
         let substruct_expectations = substructs.iter()
@@ -260,9 +262,10 @@ impl ToTokens for MockItemStruct {
         default_inits.extend(self.methods.default_inits());
         default_inits.extend(self.phantom_default_inits());
         let trait_impls = self.traits.iter()
-            .map(|ss| {
-                let modname = format_ident!("{}_{}", &self.modname, ss.name());
-                ss.trait_impl(&modname)
+            .map(|trait_| {
+                let modname = format_ident!("{}_{}", &self.modname,
+                                            trait_.ss_name());
+                trait_.trait_impl(&modname)
             }).collect::<Vec<_>>();
         let vis = &self.vis;
         quote!(


### PR DESCRIPTION
If the trait impl's self type has generic parameters, hash them.  This
allows implementing the same trait twice on a single struct, as long as
the specific generic parameters are different.  But for now, it also
requires that the mock struct is generic, limiting its usefulness.