### PR TITLE
Automatically generate Debug impls for mock structs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
-- Mockall is picker now about how you mock a trait on a generic struct.
+- Mockall is pickier now about how you mock a trait on a generic struct.
   Previously you could usually omit the generics.  Now, they're required.
   i.e.,
   ```rust

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+- automock will now automatically generate Debug implementations for traits and
+  structs.  mock! will to, if you put `#[derive(Debug)]` above the struct's
+  name.
+  ([#289](https://github.com/asomers/mockall/pull/289))
+
 - Added support for specific impls.  A specific impl is an implementation of a
   trait on a generic struct with specified generic parameters.  For example,
   `impl Foo for Bar<i32>` as opposed to `impl<T> Foo for Bar<T>`.  Mockall does

--- a/mockall/src/lib.rs
+++ b/mockall/src/lib.rs
@@ -45,6 +45,7 @@
 //! * [`Static methods`](#static-methods)
 //! * [`Modules`](#modules)
 //! * [`Foreign functions`](#foreign-functions)
+//! * [`Debug`](#debug)
 //! * [`Async Traits`](#async-traits)
 //! * [`Crate features`](#crate-features)
 //! * [`Examples`](#examples)
@@ -1030,6 +1031,22 @@
 //!     }
 //! }
 //! # fn main() {}
+//! ```
+//!
+//! ## Debug
+//!
+//! `#[automock]` will automatically generate `Debug` impls when mocking traits
+//! and struct impls.  `mock!` will too, if you add a `#[derive(Debug)]`, like
+//! this:
+//! ```no_run
+//! # use mockall::*;
+//! mock! {
+//!     #[derive(Debug)]
+//!     pub Foo {}
+//! }
+//! # fn main() {
+//! #     format!("{:?}", &MockFoo::default());
+//! # }
 //! ```
 //!
 //! ## Async Traits

--- a/mockall/tests/automock_debug.rs
+++ b/mockall/tests/automock_debug.rs
@@ -1,0 +1,35 @@
+// vim: tw=80
+//! A mocked struct should implement Debug
+#![deny(warnings)]
+
+use mockall::*;
+
+#[automock]
+pub trait Foo {}
+
+pub trait Bar {}
+pub struct Baz {}
+#[automock]
+impl Bar for Baz{}
+
+pub struct Bean {}
+#[automock]
+impl Bean{}
+
+#[test]
+fn automock_trait() {
+    let foo = MockFoo::new();
+    assert_eq!("MockFoo", format!("{:?}", foo));
+}
+
+#[test]
+fn automock_struct_impl() {
+    let bean = MockBean::new();
+    assert_eq!("MockBean", format!("{:?}", bean));
+}
+
+#[test]
+fn automock_trait_impl() {
+    let baz = MockBaz::new();
+    assert_eq!("MockBaz", format!("{:?}", baz));
+}

--- a/mockall/tests/mock_debug.rs
+++ b/mockall/tests/mock_debug.rs
@@ -1,0 +1,44 @@
+// vim: tw=80
+//! A mocked struct should implement Debug
+#![deny(warnings)]
+
+use mockall::*;
+use std::fmt::{self, Debug, Formatter};
+
+// using derive(Debug) tells mockall to generate the Debug impl automatically
+mock!{
+    #[derive(Debug)]
+    pub Bar {
+        fn foo(&self) -> u32;
+    }
+    impl Clone for Bar {
+        fn clone(&self) -> Self;
+    }
+}
+
+// With no derive(Debug), mockall won't genetate the debug impl automatically
+mock!{
+    pub Baz {
+        fn foo(&self) -> u32;
+    }
+    impl Clone for Baz {
+        fn clone(&self) -> Self;
+    }
+}
+impl Debug for MockBaz {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), fmt::Error> {
+        f.debug_struct("XXX").finish()
+    }
+}
+
+#[test]
+fn automatic() {
+    let bar = MockBar::new();
+    assert_eq!("MockBar", format!("{:?}", bar));
+}
+
+#[test]
+fn manual() {
+    let baz = MockBaz::new();
+    assert_eq!("XXX", format!("{:?}", baz));
+}

--- a/mockall_derive/src/lib.rs
+++ b/mockall_derive/src/lib.rs
@@ -565,12 +565,16 @@ impl<'a> AttrFormatter<'a> {
     // XXX This logic requires that attributes are imported with their
     // standard names.
     #[allow(clippy::needless_bool)]
+    #[allow(clippy::if_same_then_else)]
     fn format(&mut self) -> Vec<Attribute> {
         self.attrs.iter()
             .cloned()
             .filter(|attr| {
                 let i = attr.path.get_ident();
                 if i.is_none() {
+                    false
+                } else if *i.as_ref().unwrap() == "derive" {
+                    // We can't usefully derive any traits.  Ignore them
                     false
                 } else if *i.as_ref().unwrap() == "doc" {
                     self.doc

--- a/mockall_derive/src/mockable_item.rs
+++ b/mockall_derive/src/mockable_item.rs
@@ -70,7 +70,7 @@ impl From<(Attrs, ItemForeignMod)> for MockableModule {
             pub_token: <Token![pub]>::default()
         });
         let attrs = quote!(
-            #[deprecated(since = "0.9.0", note = "Using automock directly on an extern block is deprecated.  Instead, wrap the extern block in a module, and automock that, like #[automoock] mod ffi { extern \"C\" { fn foo ... } }")]
+            #[deprecated(since = "0.9.0", note = "Using automock directly on an extern block is deprecated.  Instead, wrap the extern block in a module, and automock that, like #[automock] mod ffi { extern \"C\" { fn foo ... } }")]
         );
         let mut content = vec![
             // When mocking extern blocks, we pretend that they're modules, so


### PR DESCRIPTION
Automatically generate Debug impls for mock structs.

Fixes #287 