### PR TITLE
Allow #[cfg()] attributes on trait impls in mock!

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+- `mock!` will now allow both methods and trait impls to be gated with
+  `#[cfg()]]` attributes.  The attributes will be forwarded to all generated
+  code.  This allows for example only mocking certain traits on certain OSes.
+  ([#297](https://github.com/asomers/mockall/pull/297))
+
 - automock will now automatically generate Debug implementations for traits and
   structs.  mock! will to, if you put `#[derive(Debug)]` above the struct's
   name.

--- a/mockall/tests/mock_cfg.rs
+++ b/mockall/tests/mock_cfg.rs
@@ -1,0 +1,65 @@
+// vim: tw=80
+//! mock's methods and trait impls can be conditionally compiled
+#![deny(warnings)]
+
+use mockall::*;
+
+// For this test, use the "nightly" feature as the cfg gate, because it's tested
+// both ways in CI.
+#[cfg(feature = "nightly")]
+trait Beez {
+    fn beez(&self);
+}
+#[cfg(not(feature = "nightly"))]
+trait Beez {
+    fn beez(&self, x: i32) -> i32;
+}
+
+mock! {
+    pub Foo {
+        #[cfg(feature = "nightly")]
+        fn foo(&self);
+        #[cfg(not(feature = "nightly"))]
+        fn foo(&self, x: i32) -> i32;
+    }
+    #[cfg(feature = "nightly")]
+    impl Beez for Foo {
+        fn beez(&self);
+    }
+    #[cfg(not(feature = "nightly"))]
+    impl Beez for Foo {
+        fn beez(&self, x: i32) -> i32;
+    }
+}
+
+#[test]
+#[cfg(feature = "nightly")]
+fn test_nightly_method() {
+    let mut mock = MockFoo::new();
+    mock.expect_foo()
+        .returning(|| ());
+}
+
+#[test]
+#[cfg(feature = "nightly")]
+fn test_nightly_trait() {
+    let mut mock = MockFoo::new();
+    mock.expect_beez()
+        .returning(|| ());
+}
+
+#[test]
+#[cfg(not(feature = "nightly"))]
+fn test_not_nightly_method() {
+    let mut mock = MockFoo::new();
+    mock.expect_foo()
+        .returning(|x| x + 1);
+}
+
+#[test]
+#[cfg(not(feature = "nightly"))]
+fn test_not_nightly_trait() {
+    let mut mock = MockFoo::new();
+    mock.expect_beez()
+        .returning(|x| x + 1);
+}

--- a/mockall_derive/src/mock_trait.rs
+++ b/mockall_derive/src/mock_trait.rs
@@ -11,6 +11,7 @@ use syn::{
 };
 
 use crate::{
+    AttrFormatter,
     mock_function::{self, MockFunction},
     compile_error
 };
@@ -127,7 +128,11 @@ impl MockTrait {
     // Supplying modname is an unfortunately hack.  Ideally MockTrait
     // wouldn't need to know that.
     pub fn trait_impl(&self, modname: &Ident) -> impl ToTokens {
-        let attrs = &self.attrs;
+        let trait_impl_attrs = &self.attrs;
+        let impl_attrs = AttrFormatter::new(&self.attrs)
+            .async_trait(false)
+            .doc(false)
+            .format();
         let (ig, _tg, wc) = self.generics.split_for_impl();
         let consts = &self.consts;
         let path_args = &self.self_path.arguments;
@@ -152,12 +157,13 @@ impl MockTrait {
         let self_path = &self.self_path;
         let types = &self.types;
         quote!(
-            #(#attrs)*
+            #(#trait_impl_attrs)*
             impl #ig #trait_path for #self_path #wc {
                 #(#consts)*
                 #(#types)*
                 #(#calls)*
             }
+            #(#impl_attrs)*
             impl #ig #self_path #wc {
                 #(#expects)*
                 #(#contexts)*


### PR DESCRIPTION
mock! already allowed individual methods to be so gated.  Now it will
work for trait impls, too.

Fixes #288