### PR TITLE
Fix mocking trait methods whose return values have lifetime parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [ Unreleased ] - ReleaseDate
+
+## Fixed
+
+- Fix mocking trait methods whose return values have lifetime parameters, a
+  regression since v0.10.0.
+  ([#304](https://github.com/asomers/mockall/pull/304))
+
 ## [ 0.10.0 ] - 2021-06-27
 
 ### Added

--- a/mockall_derive/src/mock_function.rs
+++ b/mockall_derive/src/mock_function.rs
@@ -619,10 +619,10 @@ impl MockFunction {
         -> impl ToTokens
     {
         let inner_mod_ident = self.inner_mod_ident();
-        if let Some(sa) = self_args {
+        if let Some(PathArguments::AngleBracketed(abga)) = self_args {
             assert!(!self.is_method_generic(),
                 "specific impls with generic methods are TODO");
-            quote!(#inner_mod_ident::Expectation #sa)
+            quote!(#inner_mod_ident::Expectation #abga)
         } else {
             // staticize any lifetimes.  This is necessary for methods that
             // return non-static types, because the Expectation itself must be


### PR DESCRIPTION
Must staticize return values for trait methods with generic arguments,
as long as the mock object itself is not generic.

This was a regression introduced by PR #274, and released in v0.10.0. It
only affects trait methods, not struct methods.

Fixes #298