### PR TITLE
Fix mocking specializing methods of non-generic structs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,20 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [ Unreleased ] - ReleaseDate
+
+### Fixed
+
+- Fix mocking specializing methods of non-generic structs, a regression in
+  v0.10.0.
+  ([#309](https://github.com/asomers/mockall/pull/309))
+
 ## [ 0.10.1 ] - 2021-07-01
 
 ### Fixed
 
 - Fix mocking trait methods whose return values have lifetime parameters, a
-  regression since v0.10.0.
+  regression in v0.10.0.
   ([#304](https://github.com/asomers/mockall/pull/304))
 
 ## [ 0.10.0 ] - 2021-06-27

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [ 0.10.1 ] - 2021-07-01
 
-## Fixed
+### Fixed
 
 - Fix mocking trait methods whose return values have lifetime parameters, a
   regression since v0.10.0.

--- a/mockall/tests/automock_specializing_method_of_nongeneric_struct.rs
+++ b/mockall/tests/automock_specializing_method_of_nongeneric_struct.rs
@@ -1,0 +1,29 @@
+// vim: tw=80
+//! Non-generic structs can have specializing methods, too.  For example, some
+//! methods place constraints on Self.  It's even possible for a where clause to
+//! place a constraint on types that appear nowhere in the struct's signatures.
+#![deny(warnings)]
+
+use mockall::*;
+
+#[automock]
+trait Bar {
+    fn bar(&self) where Self: Sized;
+    fn baz() where Self: Sized;
+}
+
+#[test]
+fn nonstatic() {
+    let mut mock = MockBar::default();
+    mock.expect_bar()
+        .return_const(());
+    mock.bar();
+}
+
+#[test]
+fn static_method() {
+    let ctx = MockBar::baz_context();
+    ctx.expect()
+        .return_const(());
+    MockBar::baz();
+}

--- a/mockall_derive/src/lib.rs
+++ b/mockall_derive/src/lib.rs
@@ -753,7 +753,7 @@ fn supersuperfy_bounds(
 /// Generate a suitable mockall::Key generic paramter from any Generics
 fn gen_keyid(g: &Generics) -> impl ToTokens {
     match g.params.len() {
-        0 => quote!(),
+        0 => quote!(<()>),
         1 => {
             let (_, tg, _) = g.split_for_impl();
             quote!(#tg)
@@ -1351,7 +1351,7 @@ mod gen_keyid {
 
     #[test]
     fn empty() {
-        check_gen_keyid(quote!(), quote!());
+        check_gen_keyid(quote!(), quote!(<()>));
     }
 
     #[test]


### PR DESCRIPTION
    Fix mocking specializing methods of non-generic structs
    
    PR #272 added support for specializing methods of generic structs, but
    broke specializing methods of nongeneric structs.
    
    Fixes #307