### PR TITLE
Revert "Suppress a buggy Clippy lint"

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -59,7 +59,5 @@ clippy_task:
     folder: $CARGO_HOME/registry
   lint_script:
     - rustup component add clippy
-    # Suppress clippy::nonstandard_macro_braces due to a clippy bug.
-    # https://github.com/asomers/mockall/issues/310
-    - cargo clippy --all-features --all-targets --workspace -- -D warnings -A clippy::nonstandard_macro_braces
+    - cargo clippy --all-features --all-targets --workspace -- -D warnings
   before_cache_script: rm -rf $CARGO_HOME/registry/index


### PR DESCRIPTION
This reverts commit 8f7efc98fffcabe1aba542ed59e60d3bdeca4a0b.
The Clippy bug has been fixed as of clippy 0.1.55 (74ef0c3e 2021-07-16)