### PR TITLE
Add count to error message

### DIFF
--- a/mockall/src/lib.rs
+++ b/mockall/src/lib.rs
@@ -1472,7 +1472,11 @@ impl Times {
             if self.range.0.end == 1 {
                 Err("should not have been called".to_owned())
             } else {
-                Err(format!("called more than {} times", self.range.0.end - 1))
+                Err(format!(
+                    "called {} times which is more than expected {}",
+                    count,
+                    self.range.0.end - 1
+                ))
             }
         } else {
             Ok(())

--- a/mockall/src/lib.rs
+++ b/mockall/src/lib.rs
@@ -1473,7 +1473,7 @@ impl Times {
                 Err("should not have been called".to_owned())
             } else {
                 Err(format!(
-                    "called {} times which is more than expected {}",
+                    "called {} times which is more than the expected {}",
                     count,
                     self.range.0.end - 1
                 ))

--- a/mockall/src/lib.rs
+++ b/mockall/src/lib.rs
@@ -1483,6 +1483,11 @@ impl Times {
         self.range.0 = 0..usize::max_value();
     }
 
+    /// Return how many times this expectation has been called
+    pub fn count(&self) -> usize {
+        self.count.load(Ordering::Relaxed)
+    }
+
     /// Has this expectation already been called the maximum allowed number of
     /// times?
     pub fn is_done(&self) -> bool {

--- a/mockall/tests/automock_many_args.rs
+++ b/mockall/tests/automock_many_args.rs
@@ -24,7 +24,7 @@ trait ManyArgs {
 
 #[test]
 #[should_panic(expected =
-    "MockManyArgs::foo: Expectation(true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true) called fewer than 1 times")]
+    "MockManyArgs::foo: Expectation(true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true) called 0 time(s) which is fewer than expected 1")]
 fn not_yet_satisfied() {
     let mut mock = MockManyArgs::new();
     mock.expect_foo()
@@ -67,7 +67,7 @@ fn static_method_returning() {
 
 #[test]
 #[should_panic(expected =
-    "MockManyArgs::foo: Expectation(true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true) called more than 1 times")]
+    "MockManyArgs::foo: Expectation(true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true) called 2 times which is more than expected 1")]
 fn too_many() {
     let mut mock = MockManyArgs::new();
     mock.expect_foo()

--- a/mockall/tests/automock_many_args.rs
+++ b/mockall/tests/automock_many_args.rs
@@ -23,8 +23,9 @@ trait ManyArgs {
 }
 
 #[test]
-#[should_panic(expected =
-    "MockManyArgs::foo: Expectation(true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true) called 0 time(s) which is fewer than expected 1")]
+#[should_panic(
+    expected = "MockManyArgs::foo: Expectation(true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true) called 0 time(s) which is fewer than expected 1"
+)]
 fn not_yet_satisfied() {
     let mut mock = MockManyArgs::new();
     mock.expect_foo()
@@ -66,8 +67,9 @@ fn static_method_returning() {
 }
 
 #[test]
-#[should_panic(expected =
-    "MockManyArgs::foo: Expectation(true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true) called 2 times which is more than expected 1")]
+#[should_panic(
+    expected = "MockManyArgs::foo: Expectation(true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true) called 2 times which is more than the expected 1"
+)]
 fn too_many() {
     let mut mock = MockManyArgs::new();
     mock.expect_foo()
@@ -77,5 +79,3 @@ fn too_many() {
     mock.foo(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
     mock.foo(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
 }
-
-

--- a/mockall/tests/mock_generic_struct_with_generic_static_method.rs
+++ b/mockall/tests/mock_generic_struct_with_generic_static_method.rs
@@ -36,7 +36,7 @@ fn checkpoint() {
 // It should also be possible to checkpoint just the context object
 #[test]
 #[should_panic(expected =
-    "MockFoo::foo2: Expectation(<anything>) called fewer than 1 times")]
+    "MockFoo::foo2: Expectation(<anything>) called 0 time(s) which is fewer than expected 1")]
 fn ctx_checkpoint() {
     let ctx = MockFoo::<u32>::foo2_context();
     ctx.expect::<i16>()

--- a/mockall/tests/mock_reference_arguments.rs
+++ b/mockall/tests/mock_reference_arguments.rs
@@ -63,7 +63,7 @@ mod times {
 
     #[test]
     #[should_panic(expected =
-                   "MockFoo::foo: Expectation(<anything>) called fewer than 2 times")]
+                   "MockFoo::foo: Expectation(<anything>) called 1 time(s) which is fewer than expected 2")]
     fn too_few() {
         let mut mock = MockFoo::new();
         mock.expect_foo()
@@ -74,7 +74,7 @@ mod times {
 
     #[test]
     #[should_panic(expected =
-        "MockFoo::foo: Expectation(<anything>) called more than 2 times")]
+        "MockFoo::foo: Expectation(<anything>) called 3 times which is more than expected 2")]
     fn too_many() {
         let mut mock = MockFoo::new();
         mock.expect_foo()
@@ -99,7 +99,7 @@ mod times {
 
     #[test]
     #[should_panic(expected =
-                   "MockFoo::foo: Expectation(<anything>) called fewer than 2 times")]
+                   "MockFoo::foo: Expectation(<anything>) called 1 time(s) which is fewer than expected 2")]
     fn range_too_few() {
         let mut mock = MockFoo::new();
         mock.expect_foo()
@@ -110,7 +110,7 @@ mod times {
 
     #[test]
     #[should_panic(expected =
-        "MockFoo::foo: Expectation(<anything>) called more than 3 times")]
+        "MockFoo::foo: Expectation(<anything>) called 4 times which is more than expected 3")]
     fn range_too_many() {
         let mut mock = MockFoo::new();
         mock.expect_foo()

--- a/mockall/tests/mock_reference_arguments.rs
+++ b/mockall/tests/mock_reference_arguments.rs
@@ -62,8 +62,9 @@ mod times {
     }
 
     #[test]
-    #[should_panic(expected =
-                   "MockFoo::foo: Expectation(<anything>) called 1 time(s) which is fewer than expected 2")]
+    #[should_panic(
+        expected = "MockFoo::foo: Expectation(<anything>) called 1 time(s) which is fewer than expected 2"
+    )]
     fn too_few() {
         let mut mock = MockFoo::new();
         mock.expect_foo()
@@ -73,8 +74,9 @@ mod times {
     }
 
     #[test]
-    #[should_panic(expected =
-        "MockFoo::foo: Expectation(<anything>) called 3 times which is more than expected 2")]
+    #[should_panic(
+        expected = "MockFoo::foo: Expectation(<anything>) called 3 times which is more than the expected 2"
+    )]
     fn too_many() {
         let mut mock = MockFoo::new();
         mock.expect_foo()
@@ -98,8 +100,9 @@ mod times {
     }
 
     #[test]
-    #[should_panic(expected =
-                   "MockFoo::foo: Expectation(<anything>) called 1 time(s) which is fewer than expected 2")]
+    #[should_panic(
+        expected = "MockFoo::foo: Expectation(<anything>) called 1 time(s) which is fewer than expected 2"
+    )]
     fn range_too_few() {
         let mut mock = MockFoo::new();
         mock.expect_foo()
@@ -109,8 +112,9 @@ mod times {
     }
 
     #[test]
-    #[should_panic(expected =
-        "MockFoo::foo: Expectation(<anything>) called 4 times which is more than expected 3")]
+    #[should_panic(
+        expected = "MockFoo::foo: Expectation(<anything>) called 4 times which is more than the expected 3"
+    )]
     fn range_too_many() {
         let mut mock = MockFoo::new();
         mock.expect_foo()

--- a/mockall/tests/mock_struct.rs
+++ b/mockall/tests/mock_struct.rs
@@ -326,7 +326,7 @@ mod times {
 
     #[test]
     #[should_panic(expected =
-        "MockFoo::baz: Expectation(<anything>) called 3 times which is more than expected 2")]
+        "MockFoo::baz: Expectation(<anything>) called 3 times which is more than the expected 2")]
     fn too_many() {
         let mut mock = MockFoo::new();
         mock.expect_baz()
@@ -369,7 +369,7 @@ mod times {
 
     #[test]
     #[should_panic(expected =
-        "MockFoo::baz: Expectation(<anything>) called 4 times which is more than expected 3")]
+        "MockFoo::baz: Expectation(<anything>) called 4 times which is more than the expected 3")]
     fn range_too_many() {
         let mut mock = MockFoo::new();
         mock.expect_baz()
@@ -396,7 +396,7 @@ mod times {
 
     #[test]
     #[should_panic(expected =
-        "MockFoo::baz: Expectation(<anything>) called 4 times which is more than expected 3")]
+        "MockFoo::baz: Expectation(<anything>) called 4 times which is more than the expected 3")]
     fn rangeto_too_many() {
         let mut mock = MockFoo::new();
         mock.expect_baz()

--- a/mockall/tests/mock_struct.rs
+++ b/mockall/tests/mock_struct.rs
@@ -42,7 +42,7 @@ mod checkpoint {
 
     #[test]
     #[should_panic(expected =
-        "MockFoo::foo: Expectation(<anything>) called fewer than 1 times")]
+        "MockFoo::foo: Expectation(<anything>) called 0 time(s) which is fewer than expected 1")]
     fn not_yet_satisfied() {
         let mut mock = MockFoo::new();
         mock.expect_foo()
@@ -314,7 +314,7 @@ mod times {
 
     #[test]
     #[should_panic(expected =
-        "MockFoo::bar: Expectation(var == 5) called fewer than 2 times")]
+        "MockFoo::bar: Expectation(var == 5) called 1 time(s) which is fewer than expected 2")]
     fn too_few() {
         let mut mock = MockFoo::new();
         mock.expect_bar()
@@ -326,7 +326,7 @@ mod times {
 
     #[test]
     #[should_panic(expected =
-        "MockFoo::baz: Expectation(<anything>) called more than 2 times")]
+        "MockFoo::baz: Expectation(<anything>) called 3 times which is more than expected 2")]
     fn too_many() {
         let mut mock = MockFoo::new();
         mock.expect_baz()
@@ -358,7 +358,7 @@ mod times {
 
     #[test]
     #[should_panic(expected =
-        "MockFoo::baz: Expectation(<anything>) called fewer than 2 times")]
+        "MockFoo::baz: Expectation(<anything>) called 1 time(s) which is fewer than expected 2")]
     fn range_too_few() {
         let mut mock = MockFoo::new();
         mock.expect_baz()
@@ -369,7 +369,7 @@ mod times {
 
     #[test]
     #[should_panic(expected =
-        "MockFoo::baz: Expectation(<anything>) called more than 3 times")]
+        "MockFoo::baz: Expectation(<anything>) called 4 times which is more than expected 3")]
     fn range_too_many() {
         let mut mock = MockFoo::new();
         mock.expect_baz()
@@ -396,7 +396,7 @@ mod times {
 
     #[test]
     #[should_panic(expected =
-        "MockFoo::baz: Expectation(<anything>) called more than 3 times")]
+        "MockFoo::baz: Expectation(<anything>) called 4 times which is more than expected 3")]
     fn rangeto_too_many() {
         let mut mock = MockFoo::new();
         mock.expect_baz()
@@ -439,7 +439,7 @@ mod times {
 
     #[test]
     #[should_panic(expected =
-        "MockFoo::baz: Expectation(<anything>) called fewer than 2 times")]
+        "MockFoo::baz: Expectation(<anything>) called 1 time(s) which is fewer than expected 2")]
     fn rangefrom_too_few() {
         let mut mock = MockFoo::new();
         mock.expect_baz()

--- a/mockall/tests/mock_struct_with_static_method.rs
+++ b/mockall/tests/mock_struct_with_static_method.rs
@@ -34,7 +34,7 @@ fn checkpoint() {
 // It should also be possible to checkpoint just the context object
 #[test]
 #[should_panic(expected =
-    "MockFoo::bar2: Expectation(<anything>) called fewer than 1 times")]
+    "MockFoo::bar2: Expectation(<anything>) called 0 time(s) which is fewer than expected 1")]
 fn ctx_checkpoint() {
     let ctx = MockFoo::bar2_context();
     ctx.expect()

--- a/mockall_derive/src/mock_function.rs
+++ b/mockall_derive/src/mock_function.rs
@@ -936,9 +936,10 @@ impl<'a> ToTokens for Common<'a> {
                     {
                         let desc = std::format!(
                             "{}", self.matcher.lock().unwrap());
-                        panic!("{}: Expectation({}) called fewer than {} times",
+                        panic!("{}: Expectation({}) called {} time(s) which is fewer than expected {}",
                                #funcname,
                                desc,
+                               self.times.count(),
                                self.times.minimum());
                     }
                 }


### PR DESCRIPTION
Thanks for the crate! It's quite useful in a project of mine.

The `times()` method on a mock will assert that the expectation has been called a specific number of times.

Unfortunately, it does not print how many times it has been called! Only the expected count...

This makes it harder to diagnose what could have gone wrong in a test.

This PR adds the expectation call count to the panic message. For example:
```
MockFoo::baz: Expectation(<anything>) called 4 times which is more than expected 3
```
or
```
MockFoo::foo: Expectation(<anything>) called 0 time(s) which is fewer than expected 1
```

For this to work, I had to expose a new method `Times::count()`.

I left out any `Cargo.toml` version update as I am not sure of the project's policy on version. Let me know if a version bump is required.