### PR TITLE
Bump out-of-date deps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,20 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+
+## [ Unreleased ] - ReleaseDate
+
+### Added
+
+- `mock!` and `#[automock]` now support `unsafe` traits.
+  ([#313](https://github.com/asomers/mockall/pull/313))
+
+### Changed
+
+- Bump `predicates` to v2.0.1, see all v2 changes in
+  [predicates' changelog](https://github.com/assert-rs/predicates-rs/blob/master/CHANGELOG.md).
+  ([#317](https://github.com/asomers/mockall/pull/317))
+
 ## [ 0.10.2 ] - 2021-07-12
 
 ### Fixed
@@ -14,6 +28,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Fix mocking generic methods of generic structs returning nonstatic, a
   regression in v0.10.0.
   ([#312](https://github.com/asomers/mockall/pull/312))
+
 
 ## [ 0.10.1 ] - 2021-07-01
 

--- a/mockall/Cargo.toml
+++ b/mockall/Cargo.toml
@@ -41,7 +41,7 @@ cfg-if = "1.0"
 downcast = "0.10"
 fragile = "1.0"
 lazy_static = "1.1"
-predicates = "1.0.2"
+predicates = "2.0.1"
 predicates-tree = "1.0"
 mockall_derive = { version = "= 0.10.2", path = "../mockall_derive" }
 

--- a/mockall/src/lib.rs
+++ b/mockall/src/lib.rs
@@ -1472,7 +1472,11 @@ impl Times {
             if self.range.0.end == 1 {
                 Err("should not have been called".to_owned())
             } else {
-                Err(format!("called more than {} times", self.range.0.end - 1))
+                Err(format!(
+                    "called {} times which is more than the expected {}",
+                    count,
+                    self.range.0.end - 1
+                ))
             }
         } else {
             Ok(())
@@ -1481,6 +1485,11 @@ impl Times {
 
     pub fn any(&mut self) {
         self.range.0 = 0..usize::max_value();
+    }
+
+    /// Return how many times this expectation has been called
+    pub fn count(&self) -> usize {
+        self.count.load(Ordering::Relaxed)
     }
 
     /// Has this expectation already been called the maximum allowed number of

--- a/mockall/tests/automock_gat.rs
+++ b/mockall/tests/automock_gat.rs
@@ -1,0 +1,36 @@
+#! vim: tw=80
+//! automock a trait with Generic Associated Types
+#![cfg_attr(feature = "nightly", feature(generic_associated_types))]
+#![deny(warnings)]
+
+use cfg_if::cfg_if;
+
+cfg_if! {
+    if #[cfg(feature = "nightly")] {
+        use mockall::*;
+
+        // The lifetime must have the same name as in the next() method.
+        #[automock(type Item=&'a u32;)]
+        trait LendingIterator {
+            type Item<'a> where Self: 'a;
+
+            // Clippy doesn't know that Mockall will need the liftime when it
+            // expands the macro.
+            #[allow(clippy::needless_lifetimes)]
+            fn next<'a>(&'a mut self) -> Option<Self::Item<'a>>;
+        }
+
+        // It isn't possible to safely set an expectation for a non-'static
+        // return value (because the mock object doesn't have any lifetime
+        // parameters itself), but unsafely setting such an expectation is a
+        // common use case.
+        #[test]
+        fn return_const() {
+            let mut mock = MockLendingIterator::new();
+            let x = 42u32;
+            let xstatic: &'static u32 = unsafe{ std::mem::transmute(&x) };
+            mock.expect_next().return_const(Some(xstatic));
+            assert_eq!(42u32, *mock.next().unwrap());
+        }
+    }
+}

--- a/mockall/tests/automock_many_args.rs
+++ b/mockall/tests/automock_many_args.rs
@@ -23,8 +23,9 @@ trait ManyArgs {
 }
 
 #[test]
-#[should_panic(expected =
-    "MockManyArgs::foo: Expectation(true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true) called fewer than 1 times")]
+#[should_panic(
+    expected = "MockManyArgs::foo: Expectation(true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true) called 0 time(s) which is fewer than expected 1"
+)]
 fn not_yet_satisfied() {
     let mut mock = MockManyArgs::new();
     mock.expect_foo()
@@ -66,8 +67,9 @@ fn static_method_returning() {
 }
 
 #[test]
-#[should_panic(expected =
-    "MockManyArgs::foo: Expectation(true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true) called more than 1 times")]
+#[should_panic(
+    expected = "MockManyArgs::foo: Expectation(true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true) called 2 times which is more than the expected 1"
+)]
 fn too_many() {
     let mut mock = MockManyArgs::new();
     mock.expect_foo()
@@ -77,5 +79,3 @@ fn too_many() {
     mock.foo(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
     mock.foo(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
 }
-
-

--- a/mockall/tests/automock_unsafe_trait.rs
+++ b/mockall/tests/automock_unsafe_trait.rs
@@ -1,0 +1,36 @@
+// vim: ts=80
+#![deny(warnings)]
+
+use mockall::*;
+
+#[automock]
+pub unsafe trait Foo {
+    fn foo(&self) -> i32;
+}
+
+struct Baz{}
+
+#[automock]
+unsafe impl Foo for Baz {
+    fn foo(&self) -> i32 {
+        unimplemented!()
+    }
+}
+
+#[test]
+fn automock_trait() {
+    let mut mock = MockFoo::new();
+    mock.expect_foo()
+        .return_const(42);
+
+    assert_eq!(42, mock.foo());
+}
+
+#[test]
+fn automock_trait_impl() {
+    let mut mock = MockBaz::new();
+    mock.expect_foo()
+        .return_const(42);
+
+    assert_eq!(42, mock.foo());
+}

--- a/mockall/tests/mock_generic_struct_with_generic_static_method.rs
+++ b/mockall/tests/mock_generic_struct_with_generic_static_method.rs
@@ -36,7 +36,7 @@ fn checkpoint() {
 // It should also be possible to checkpoint just the context object
 #[test]
 #[should_panic(expected =
-    "MockFoo::foo2: Expectation(<anything>) called fewer than 1 times")]
+    "MockFoo::foo2: Expectation(<anything>) called 0 time(s) which is fewer than expected 1")]
 fn ctx_checkpoint() {
     let ctx = MockFoo::<u32>::foo2_context();
     ctx.expect::<i16>()

--- a/mockall/tests/mock_reference_arguments.rs
+++ b/mockall/tests/mock_reference_arguments.rs
@@ -62,8 +62,9 @@ mod times {
     }
 
     #[test]
-    #[should_panic(expected =
-                   "MockFoo::foo: Expectation(<anything>) called fewer than 2 times")]
+    #[should_panic(
+        expected = "MockFoo::foo: Expectation(<anything>) called 1 time(s) which is fewer than expected 2"
+    )]
     fn too_few() {
         let mut mock = MockFoo::new();
         mock.expect_foo()
@@ -73,8 +74,9 @@ mod times {
     }
 
     #[test]
-    #[should_panic(expected =
-        "MockFoo::foo: Expectation(<anything>) called more than 2 times")]
+    #[should_panic(
+        expected = "MockFoo::foo: Expectation(<anything>) called 3 times which is more than the expected 2"
+    )]
     fn too_many() {
         let mut mock = MockFoo::new();
         mock.expect_foo()
@@ -98,8 +100,9 @@ mod times {
     }
 
     #[test]
-    #[should_panic(expected =
-                   "MockFoo::foo: Expectation(<anything>) called fewer than 2 times")]
+    #[should_panic(
+        expected = "MockFoo::foo: Expectation(<anything>) called 1 time(s) which is fewer than expected 2"
+    )]
     fn range_too_few() {
         let mut mock = MockFoo::new();
         mock.expect_foo()
@@ -109,8 +112,9 @@ mod times {
     }
 
     #[test]
-    #[should_panic(expected =
-        "MockFoo::foo: Expectation(<anything>) called more than 3 times")]
+    #[should_panic(
+        expected = "MockFoo::foo: Expectation(<anything>) called 4 times which is more than the expected 3"
+    )]
     fn range_too_many() {
         let mut mock = MockFoo::new();
         mock.expect_foo()

--- a/mockall/tests/mock_struct.rs
+++ b/mockall/tests/mock_struct.rs
@@ -42,7 +42,7 @@ mod checkpoint {
 
     #[test]
     #[should_panic(expected =
-        "MockFoo::foo: Expectation(<anything>) called fewer than 1 times")]
+        "MockFoo::foo: Expectation(<anything>) called 0 time(s) which is fewer than expected 1")]
     fn not_yet_satisfied() {
         let mut mock = MockFoo::new();
         mock.expect_foo()
@@ -314,7 +314,7 @@ mod times {
 
     #[test]
     #[should_panic(expected =
-        "MockFoo::bar: Expectation(var == 5) called fewer than 2 times")]
+        "MockFoo::bar: Expectation(var == 5) called 1 time(s) which is fewer than expected 2")]
     fn too_few() {
         let mut mock = MockFoo::new();
         mock.expect_bar()
@@ -326,7 +326,7 @@ mod times {
 
     #[test]
     #[should_panic(expected =
-        "MockFoo::baz: Expectation(<anything>) called more than 2 times")]
+        "MockFoo::baz: Expectation(<anything>) called 3 times which is more than the expected 2")]
     fn too_many() {
         let mut mock = MockFoo::new();
         mock.expect_baz()
@@ -358,7 +358,7 @@ mod times {
 
     #[test]
     #[should_panic(expected =
-        "MockFoo::baz: Expectation(<anything>) called fewer than 2 times")]
+        "MockFoo::baz: Expectation(<anything>) called 1 time(s) which is fewer than expected 2")]
     fn range_too_few() {
         let mut mock = MockFoo::new();
         mock.expect_baz()
@@ -369,7 +369,7 @@ mod times {
 
     #[test]
     #[should_panic(expected =
-        "MockFoo::baz: Expectation(<anything>) called more than 3 times")]
+        "MockFoo::baz: Expectation(<anything>) called 4 times which is more than the expected 3")]
     fn range_too_many() {
         let mut mock = MockFoo::new();
         mock.expect_baz()
@@ -396,7 +396,7 @@ mod times {
 
     #[test]
     #[should_panic(expected =
-        "MockFoo::baz: Expectation(<anything>) called more than 3 times")]
+        "MockFoo::baz: Expectation(<anything>) called 4 times which is more than the expected 3")]
     fn rangeto_too_many() {
         let mut mock = MockFoo::new();
         mock.expect_baz()
@@ -439,7 +439,7 @@ mod times {
 
     #[test]
     #[should_panic(expected =
-        "MockFoo::baz: Expectation(<anything>) called fewer than 2 times")]
+        "MockFoo::baz: Expectation(<anything>) called 1 time(s) which is fewer than expected 2")]
     fn rangefrom_too_few() {
         let mut mock = MockFoo::new();
         mock.expect_baz()

--- a/mockall/tests/mock_struct_with_static_method.rs
+++ b/mockall/tests/mock_struct_with_static_method.rs
@@ -34,7 +34,7 @@ fn checkpoint() {
 // It should also be possible to checkpoint just the context object
 #[test]
 #[should_panic(expected =
-    "MockFoo::bar2: Expectation(<anything>) called fewer than 1 times")]
+    "MockFoo::bar2: Expectation(<anything>) called 0 time(s) which is fewer than expected 1")]
 fn ctx_checkpoint() {
     let ctx = MockFoo::bar2_context();
     ctx.expect()

--- a/mockall/tests/mock_unsafe_trait.rs
+++ b/mockall/tests/mock_unsafe_trait.rs
@@ -1,0 +1,24 @@
+// vim: ts=80
+#![deny(warnings)]
+
+use mockall::*;
+
+pub unsafe trait Bar {
+    fn bar(&self) -> i32;
+}
+
+mock! {
+    pub Foo{}
+    unsafe impl Bar for Foo {
+        fn bar(&self) -> i32;
+    }
+}
+
+#[test]
+fn return_const() {
+    let mut mock = MockFoo::new();
+    mock.expect_bar()
+        .return_const(42);
+
+    assert_eq!(42, mock.bar());
+}

--- a/mockall_derive/Cargo.toml
+++ b/mockall_derive/Cargo.toml
@@ -33,4 +33,4 @@ quote = "1.0"
 syn = { version = "1.0.15", features = ["extra-traits", "full"] }
 
 [dev-dependencies]
-pretty_assertions = "0.5"
+pretty_assertions = "0.7"

--- a/mockall_derive/src/mock_function.rs
+++ b/mockall_derive/src/mock_function.rs
@@ -936,9 +936,10 @@ impl<'a> ToTokens for Common<'a> {
                     {
                         let desc = std::format!(
                             "{}", self.matcher.lock().unwrap());
-                        panic!("{}: Expectation({}) called fewer than {} times",
+                        panic!("{}: Expectation({}) called {} time(s) which is fewer than expected {}",
                                #funcname,
                                desc,
+                               self.times.count(),
                                self.times.minimum());
                     }
                 }

--- a/mockall_derive/src/mock_trait.rs
+++ b/mockall_derive/src/mock_trait.rs
@@ -28,7 +28,8 @@ pub(crate) struct MockTrait {
     /// Path on which the trait is implemented.  Usually will be the same as
     /// structname, but might include concrete generic parameters.
     self_path: PathSegment,
-    pub types: Vec<ImplItemType>
+    pub types: Vec<ImplItemType>,
+    pub unsafety: Option<Token![unsafe]>
 }
 
 impl MockTrait {
@@ -116,7 +117,8 @@ impl MockTrait {
             ss_name,
             trait_path,
             self_path,
-            types
+            types,
+            unsafety: impl_.unsafety
         }
     }
 
@@ -156,9 +158,10 @@ impl MockTrait {
         let trait_path = &self.trait_path;
         let self_path = &self.self_path;
         let types = &self.types;
+        let unsafety = &self.unsafety;
         quote!(
             #(#trait_impl_attrs)*
-            impl #ig #trait_path for #self_path #wc {
+            #unsafety impl #ig #trait_path for #self_path #wc {
                 #(#consts)*
                 #(#types)*
                 #(#calls)*


### PR DESCRIPTION
Signed-off-by: Chojan Shang <psiace@outlook.com>

- `predicates = "2.0.1"`
- `pretty_assertions = "0.7"`

```
Crate:         difference
Version:       2.0.0
Warning:       unmaintained
Title:         difference is unmaintained
Date:          2020-12-20
ID:            RUSTSEC-2020-0095
URL:           https://rustsec.org/advisories/RUSTSEC-2020-0095
Dependency tree: 
difference 2.0.0
└── predicates 1.0.8
    └── mockall 0.10.2

```