### PR TITLE
Fix nondeterministic macro output

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -1,2 +1,9 @@
 # I use a lot of dumb names in the tests
 blacklisted-names = []
+
+# It is naughty for a code generator to produce nondeterministic output.
+# Use UnorderedMap/Set instead.
+disallowed-types = [
+    "std::collections::HashMap",
+    "std::collections::HashSet",
+]

--- a/mockall_derive/src/automock.rs
+++ b/mockall_derive/src/automock.rs
@@ -1,6 +1,6 @@
 // vim: tw=80
 use super::*;
-use std::collections::HashMap;
+use crate::collections::UnorderedMap;
 use syn::parse::{Parse, ParseStream};
 
 /// A single automock attribute
@@ -27,7 +27,7 @@ impl Parse for Attr {
 /// automock attributes
 #[derive(Debug, Default)]
 pub(crate) struct Attrs {
-    pub attrs: HashMap<Ident, Type>,
+    pub attrs: UnorderedMap<Ident, Type>,
     pub modname: Option<Ident>
 }
 
@@ -249,7 +249,7 @@ impl Attrs {
 
 impl Parse for Attrs {
     fn parse(input: ParseStream) -> parse::Result<Self> {
-        let mut attrs = HashMap::new();
+        let mut attrs = UnorderedMap::new();
         let mut modname = None;
         while !input.is_empty() {
             let attr: Attr = input.parse()?;

--- a/mockall_derive/src/collections.rs
+++ b/mockall_derive/src/collections.rs
@@ -17,21 +17,23 @@ use std::hash::Hash;
 use std::iter::FromIterator;
 
 #[derive(Debug)]
-pub struct UnorderedMap<K, V>(HashMap<K, V>);
+pub struct UnorderedMap<K, V>(HashMap<K, V>)
+where
+    K: Eq + Hash;
 
 #[derive(Debug)]
-pub struct UnorderedSet<T>(HashSet<T>);
-
-impl<K, V> UnorderedMap<K, V> {
-    pub fn new() -> Self {
-        UnorderedMap(HashMap::new())
-    }
-}
+pub struct UnorderedSet<T>(HashSet<T>)
+where
+    T: Eq + Hash;
 
 impl<K, V> UnorderedMap<K, V>
 where
     K: Eq + Hash,
 {
+    pub fn new() -> Self {
+        UnorderedMap(HashMap::new())
+    }
+
     pub fn insert(&mut self, k: K, v: V) -> Option<V> {
         self.0.insert(k, v)
     }
@@ -74,13 +76,19 @@ where
     }
 }
 
-impl<K, V> Default for UnorderedMap<K, V> {
+impl<K, V> Default for UnorderedMap<K, V>
+where
+    K: Eq + Hash,
+{
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl<T> Default for UnorderedSet<T> {
+impl<T> Default for UnorderedSet<T>
+where
+    T: Eq + Hash,
+{
     fn default() -> Self {
         UnorderedSet(HashSet::default())
     }

--- a/mockall_derive/src/collections.rs
+++ b/mockall_derive/src/collections.rs
@@ -1,0 +1,99 @@
+//! A map and set that are safe for code generator use.
+//!
+//! *Do not add any IntoIterator impl to these.* Only insertion, membership
+//! checking, and map lookup are exposed. Iteration order is not exposed.
+//!
+//! It's never correct for a code generator to produce nondeterministic output,
+//! so iterating over a randomized hash based collection is bad. Even iterating
+//! over a b-tree collection is non ideal -- it's always better to produce
+//! output that follows source order. We enforce this in mockall_derive via
+//! these wrapper types and the Clippy disallowed_type lint.
+
+#![allow(clippy::disallowed_type)]
+
+use std::borrow::Borrow;
+use std::collections::{HashMap, HashSet};
+use std::hash::Hash;
+use std::iter::FromIterator;
+
+#[derive(Debug)]
+pub struct UnorderedMap<K, V>(HashMap<K, V>);
+
+#[derive(Debug)]
+pub struct UnorderedSet<T>(HashSet<T>);
+
+impl<K, V> UnorderedMap<K, V> {
+    pub fn new() -> Self {
+        UnorderedMap(HashMap::new())
+    }
+}
+
+impl<K, V> UnorderedMap<K, V>
+where
+    K: Eq + Hash,
+{
+    pub fn insert(&mut self, k: K, v: V) -> Option<V> {
+        self.0.insert(k, v)
+    }
+
+    pub fn contains_key<Q>(&self, k: &Q) -> bool
+    where
+        K: Borrow<Q>,
+        Q: ?Sized + Hash + Eq,
+    {
+        self.0.contains_key(k)
+    }
+
+    pub fn get<Q>(&self, k: &Q) -> Option<&V>
+    where
+        K: Borrow<Q>,
+        Q: ?Sized + Hash + Eq,
+    {
+        self.0.get(k)
+    }
+}
+
+impl<T> UnorderedSet<T>
+where
+    T: Eq + Hash,
+{
+    pub fn insert(&mut self, value: T) -> bool {
+        self.0.insert(value)
+    }
+
+    pub fn contains<Q>(&self, value: &Q) -> bool
+    where
+        T: Borrow<Q>,
+        Q: ?Sized + Hash + Eq,
+    {
+        self.0.contains(value)
+    }
+
+    pub fn extend(&mut self, set: Self) {
+        self.0.extend(set.0)
+    }
+}
+
+impl<K, V> Default for UnorderedMap<K, V> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<T> Default for UnorderedSet<T> {
+    fn default() -> Self {
+        UnorderedSet(HashSet::default())
+    }
+}
+
+impl<T> FromIterator<T> for UnorderedSet<T>
+where
+    T: Eq + Hash,
+{
+    fn from_iter<I>(iter: I) -> Self
+    where
+        I: IntoIterator<Item = T>,
+    {
+        UnorderedSet(HashSet::from_iter(iter))
+    }
+}

--- a/mockall_derive/src/mock_function.rs
+++ b/mockall_derive/src/mock_function.rs
@@ -257,12 +257,14 @@ impl<'a> Builder<'a> {
         let egenerics = merge_generics(
             &merge_generics(&cgenerics, &srltg),
             &mrltg);
-        let alifetimes = salifetimes.into_iter()
-            .collect::<HashSet<LifetimeDef>>()
-            .union(&malifetimes.into_iter().collect::<HashSet<_>>())
-            .into_iter()
-            .cloned()
-            .collect();
+
+        let mut dedup_alifetimes = salifetimes.iter().cloned().collect::<UnorderedSet<_>>();
+        let mut alifetimes = salifetimes;
+        for lifetime in malifetimes {
+            if dedup_alifetimes.insert(lifetime.clone()) {
+                alifetimes.push(lifetime);
+            }
+        }
 
         let fn_params = egenerics.type_params()
             .map(|tp| tp.ident.clone())

--- a/mockall_derive/src/mock_item_struct.rs
+++ b/mockall_derive/src/mock_item_struct.rs
@@ -2,9 +2,9 @@
 use super::*;
 
 use quote::ToTokens;
-use std::collections::HashSet;
 
 use crate::{
+    collections::UnorderedSet,
     mock_function::MockFunction,
     mock_trait::MockTrait
 };
@@ -58,7 +58,7 @@ fn phantom_fields(generics: &Generics) -> Vec<TokenStream> {
 fn unique_trait_iter<'a, I: Iterator<Item = &'a MockTrait>>(i: I)
     -> impl Iterator<Item = &'a MockTrait>
 {
-    let mut hs = HashSet::<(Path, Vec<Attribute>)>::default();
+    let mut hs = UnorderedSet::<(Path, Vec<Attribute>)>::default();
     i.filter(move |mt| {
         let impl_attrs = AttrFormatter::new(&mt.attrs)
             .async_trait(false)


### PR DESCRIPTION
The automock attribute currently creates nondeterministic output, which breaks in environments that cache crate compilations, and causes unnecessary rebuilds of downstream code when the code shouldn't have changed.

Repro:

```rust
#[mockall::automock]
trait Trait {
    fn f<'a, 'b>(s: &'a &'b str);
}
```

Running `cargo expand | rg "for<'., '.>"` this shows mockall sometimes expanding to:

<pre>
Mut(Box&lt;dyn <b>for&lt;'b, 'a&gt;</b> FnMut(&'a &'b str) -&gt; () + Send&gt;),
MutSt(::mockall::Fragile&lt;Box&lt;dyn <b>for&lt;'b, 'a&gt;</b> FnMut(&'a &'b str) -&gt; ()&gt;&gt;),
Once(Box&lt;dyn <b>for&lt;'b, 'a&gt;</b> FnOnce(&'a &'b str) -&gt; () + Send&gt;),
OnceSt(::mockall::Fragile&lt;Box&lt;dyn <b>for&lt;'b, 'a&gt;</b> FnOnce(&'a &'b str) -&gt; ()&gt;&gt;),
Func(Box&lt;dyn <b>for&lt;'b, 'a&gt;</b> Fn(&&'b str) -&gt; bool + Send&gt;),
FuncSt(::mockall::Fragile&lt;Box&lt;dyn <b>for&lt;'b, 'a&gt;</b> Fn(&&'b str) -&gt; bool&gt;&gt;),
Pred(Box&lt;(Box&lt;dyn <b>for&lt;'b, 'a&gt;</b> ::mockall::Predicate&lt;&'b str&gt; + Send&gt;,)&gt;),
fn with&lt;MockallMatcher0: <b>for&lt;'b, 'a&gt;</b> ::mockall::Predicate&lt;&'b str&gt; + Send + 'static&gt;(
</pre>

and sometimes to:

<pre>
Mut(Box&lt;dyn <b>for&lt;'a, 'b&gt;</b> FnMut(&'a &'b str) -&gt; () + Send&gt;),
MutSt(::mockall::Fragile&lt;Box&lt;dyn <b>for&lt;'a, 'b&gt;</b> FnMut(&'a &'b str) -&gt; ()&gt;&gt;),
Once(Box&lt;dyn <b>for&lt;'a, 'b&gt;</b> FnOnce(&'a &'b str) -&gt; () + Send&gt;),
OnceSt(::mockall::Fragile&lt;Box&lt;dyn <b>for&lt;'a, 'b&gt;</b> FnOnce(&'a &'b str) -&gt; ()&gt;&gt;),
Func(Box&lt;dyn <b>for&lt;'a, 'b&gt;</b> Fn(&&'b str) -&gt; bool + Send&gt;),
FuncSt(::mockall::Fragile&lt;Box&lt;dyn <b>for&lt;'a, 'b&gt;</b> Fn(&&'b str) -&gt; bool&gt;&gt;),
Pred(Box&lt;(Box&lt;dyn <b>for&lt;'a, 'b&gt;</b> ::mockall::Predicate&lt;&'b str&gt; + Send&gt;,)&gt;),
fn with&lt;MockallMatcher0: <b>for&lt;'a, 'b&gt;</b> ::mockall::Predicate&lt;&'b str&gt; + Send + 'static&gt;(
</pre>

The source of the nondeterminism is iterating over a randomized HashSet.

This PR fixes the nondeterminism and uses https://rust-lang.github.io/rust-clippy/master/index.html#disallowed_type to disallow iteration of hash based collections in the future.