### PR TITLE
Fix nondeterministic code generation

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -35,6 +35,8 @@ task:
   lint_script:
     - rustup component add clippy
     - cargo clippy $CARGO_ARGS --all-targets --workspace -- -D warnings
+  reproducibility_script:
+    - env RUSTFLAGS="--cfg reprocheck" cargo check $CARGO_ARGS --all-targets
   minver_script:
     - cargo update -Zminimal-versions
     - cargo test $CARGO_ARGS

--- a/mockall/tests/automock_multiple_lifetime_parameters.rs
+++ b/mockall/tests/automock_multiple_lifetime_parameters.rs
@@ -1,0 +1,15 @@
+// vim: tw=80
+//! Methods with multiple generic lifetime parameters should produce their
+//! generated code deterministically.
+//!
+//! This test is designed to work with "--cfg reprocheck"
+
+#![deny(warnings)]
+#![allow(clippy::needless_lifetimes)]
+
+use mockall::*;
+
+#[automock]
+trait Foo {
+    fn foo<'a, 'b, 'c, 'd, 'e, 'f>(&self, x: &'a &'b &'c &'d &'e &'f i32);
+}

--- a/mockall_derive/src/lib.rs
+++ b/mockall_derive/src/lib.rs
@@ -12,8 +12,8 @@ use cfg_if::cfg_if;
 use proc_macro2::{Span, TokenStream};
 use quote::{ToTokens, format_ident, quote};
 use std::{
-    collections::{HashMap, HashSet},
     env,
+    hash::BuildHasherDefault
 };
 use syn::{
     *,
@@ -33,6 +33,10 @@ use crate::mockable_struct::MockableStruct;
 use crate::mock_item::MockItem;
 use crate::mock_item_struct::MockItemStruct;
 use crate::mockable_item::MockableItem;
+
+// Define deterministic aliases for these common types.
+type HashMap<K, V> = std::collections::HashMap<K, V, BuildHasherDefault<std::collections::hash_map::DefaultHasher>>;
+type HashSet<K> = std::collections::HashSet<K, BuildHasherDefault<std::collections::hash_map::DefaultHasher>>;
 
 cfg_if! {
     // proc-macro2's Span::unstable method requires the nightly feature, and it
@@ -126,7 +130,7 @@ fn deanonymize(literal_type: &mut Type) {
 fn declosurefy(gen: &Generics, args: &Punctuated<FnArg, Token![,]>) ->
     (Generics, Vec<FnArg>, Vec<TokenStream>)
 {
-    let mut hm = HashMap::new();
+    let mut hm = HashMap::default();
 
     let mut save_fn_types = |ident: &Ident, tpb: &TypeParamBound| {
         if let TypeParamBound::Trait(tb) = tpb {


### PR DESCRIPTION
mockall_derive was internally using HashMap and HashSet and iterating
over their contents.  But by default those types use random internal
state, resulting in nondeterministic output.  Switch them to use
consistent state.
    
Reported by:    David Tolnay @dtolnay

Also, add a CI check for nondeterminism.  When enabled, mock! and
#[automock] will evaluate every call twice and verify that the output is identical.
Also add a test case that is known to currently generate
non-reproducible output.  During CI, build the entire test suite with
this mode enabled.