### PR TITLE
fix `Box<dyn A>: A` required in returning `&dyn A` for #363

### DIFF
--- a/mockall/tests/mock_return_dyn_trait.rs
+++ b/mockall/tests/mock_return_dyn_trait.rs
@@ -10,6 +10,23 @@ trait T: Debug + Sync {
 }
 
 impl T for u32 {}
+trait Base {
+    fn as_t(&self) -> &dyn T;
+}
+trait Derived: Base {
+    fn as_base(&self) -> &dyn Base;
+}
+
+impl Base for u32 {
+    fn as_t(&self) -> &dyn T {
+        self
+    }
+}
+impl Derived for u32 {
+    fn as_base(&self) -> &dyn Base {
+        self
+    }
+}
 
 impl<Q> T for Q where Q: Debug + Sync + AsMut<dyn T> {}
 
@@ -18,6 +35,16 @@ mock!{
         fn foo(&self) -> &dyn Debug;
         fn bar(&self) -> &'static dyn T;
         fn baz(&mut self) -> &mut dyn T;
+    }
+}
+
+mock! {
+    Bar {}
+    impl Base for Bar {
+        fn as_t(&self) -> &dyn T;
+    }
+    impl Derived for Bar {
+        fn as_base(&self) -> &dyn Base;
     }
 }
 
@@ -46,4 +73,13 @@ fn return_var() {
         .return_var(Box::new(42u32) as Box<dyn T>);
 
     mock.baz().mutate();
+}
+
+#[test]
+fn dyn_upcast() {
+    let mut mock = MockBar::new();
+    mock.expect_as_t()
+        .return_const(Box::new(42u32) as Box<dyn T>);
+
+    assert_eq!("42", format!("{:?}", mock.as_t()));
 }


### PR DESCRIPTION
fixes #363.