### PR TITLE
Add the ability to double type aliases to mockall_double

### DIFF
--- a/mockall_double/CHANGELOG.md
+++ b/mockall_double/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+This project adheres to [Semantic Versioning](http://semver.org/).
+
+
+## [ Unreleased ] - ReleaseDate
+
+### Added
+
+- Added the ability to mock type aliases.
+  ([#374](https://github.com/asomers/mockall/pull/374))


### PR DESCRIPTION
```rust
 #[double]
type Foo = bar::Baz;
```
will become
```rust
 #[cfg(not(test))]
type Foo = bar::Baz;
 #[cfg(test)]
type Foo = bar::MockBaz;
```