### PR TITLE
clippy cleanup

### DIFF
--- a/mockall/tests/automock_instrument.rs
+++ b/mockall/tests/automock_instrument.rs
@@ -2,6 +2,7 @@
 //! A trait that uses tracing::instrument should be automockable.  The mock
 //! method won't be instrumented, though.
 #![deny(warnings)]
+#![allow(dead_code)]
 
 use mockall::*;
 use tracing::instrument;

--- a/mockall/tests/automock_module_nonpub.rs
+++ b/mockall/tests/automock_module_nonpub.rs
@@ -1,6 +1,7 @@
 // vim: tw=80
 //! bare functions can use non-public types, as long as the object's visibility is compatible.
 #![deny(warnings)]
+#![allow(dead_code)]
 
 mod outer {
     struct SuperT();
@@ -11,7 +12,6 @@ mod outer {
         pub(crate) struct PubCrateT();
         struct PrivT();
 
-        #[allow(dead_code)]
         #[automock]
         mod m {
             use super::*;

--- a/mockall/tests/mock_associated_const.rs
+++ b/mockall/tests/mock_associated_const.rs
@@ -17,7 +17,6 @@ trait Foo {
 mock! {
     Foo {
         const Y: i32 = 69;
-        fn foo(&self);
     }
     impl Foo for Foo {
         const X: i32 = 42;

--- a/mockall/tests/mock_cfg.rs
+++ b/mockall/tests/mock_cfg.rs
@@ -1,6 +1,7 @@
 // vim: tw=80
 //! mock's methods and trait impls can be conditionally compiled
 #![deny(warnings)]
+#![allow(dead_code)]
 
 use mockall::*;
 

--- a/mockall/tests/mock_constructor_with_args.rs
+++ b/mockall/tests/mock_constructor_with_args.rs
@@ -8,7 +8,6 @@ use mockall::*;
 
 mock! {
     pub Foo {
-        fn foo(&self) -> u32;
         fn new(x: u32) -> Self;
     }
 }

--- a/mockall/tests/mock_debug.rs
+++ b/mockall/tests/mock_debug.rs
@@ -8,9 +8,7 @@ use std::fmt::{self, Debug, Formatter};
 // using derive(Debug) tells mockall to generate the Debug impl automatically
 mock!{
     #[derive(Debug)]
-    pub Bar {
-        fn foo(&self) -> u32;
-    }
+    pub Bar { }
     impl Clone for Bar {
         fn clone(&self) -> Self;
     }
@@ -18,9 +16,7 @@ mock!{
 
 // With no derive(Debug), mockall won't genetate the debug impl automatically
 mock!{
-    pub Baz {
-        fn foo(&self) -> u32;
-    }
+    pub Baz { }
     impl Clone for Baz {
         fn clone(&self) -> Self;
     }

--- a/mockall/tests/mock_docs.rs
+++ b/mockall/tests/mock_docs.rs
@@ -1,6 +1,7 @@
 // vim: tw=80
 #![deny(missing_docs)]
 #![deny(warnings)]
+#![allow(dead_code)]
 
 use mockall::*;
 

--- a/mockall/tests/mock_generic_method_on_generic_struct_returning_nonstatic.rs
+++ b/mockall/tests/mock_generic_method_on_generic_struct_returning_nonstatic.rs
@@ -59,7 +59,7 @@ fn return_static_ref() {
     thing.expect_baz()
         .return_const(x);
 
-    assert_eq!(42u32, *(*thing.baz()).0);
+    assert_eq!(42u32, *thing.baz().0);
 }
 
 // It isn't possible to safely set an expectation for a non-'static return value
@@ -99,7 +99,7 @@ mod trait_methods {
         thing.expect_trait_baz()
             .return_const(x);
 
-        assert_eq!(42u32, *(*thing.trait_baz()).0);
+        assert_eq!(42u32, *thing.trait_baz().0);
     }
 
     #[test]

--- a/mockall/tests/mock_generic_method_returning_nonstatic.rs
+++ b/mockall/tests/mock_generic_method_returning_nonstatic.rs
@@ -60,7 +60,7 @@ fn return_static_ref() {
     thing.expect_baz()
         .return_const(x);
 
-    assert_eq!(42u32, *(*thing.baz()).0);
+    assert_eq!(42u32, *thing.baz().0);
 }
 
 // It isn't possible to safely set an expectation for a non-'static return value
@@ -100,7 +100,7 @@ mod trait_methods {
         thing.expect_trait_baz()
             .return_const(x);
 
-        assert_eq!(42u32, *(*thing.trait_baz()).0);
+        assert_eq!(42u32, *thing.trait_baz().0);
     }
 
     #[test]

--- a/mockall/tests/mock_generic_struct_with_generic_static_method.rs
+++ b/mockall/tests/mock_generic_struct_with_generic_static_method.rs
@@ -10,6 +10,7 @@ mock! {
         fn foo<Q: 'static>(t: T, q: Q) -> u64;
         // We must use a different method for every should_panic test, so the
         // shared mutex doesn't get poisoned.
+        #[allow(dead_code)]
         fn foo2<Q: 'static>(t: T, q: Q) -> u64;
         fn foo3<Q: 'static>(t: T, q: Q) -> u64;
     }

--- a/mockall/tests/mock_life0.rs
+++ b/mockall/tests/mock_life0.rs
@@ -2,6 +2,7 @@
 //! mock a method whose self parameter has an explicit lifetime
 //! https://github.com/asomers/mockall/issues/95
 #![deny(warnings)]
+#![allow(dead_code)]
 
 use mockall::*;
 

--- a/mockall/tests/mock_nonpub.rs
+++ b/mockall/tests/mock_nonpub.rs
@@ -2,6 +2,7 @@
 //! methods can use non-public types, as long as the object's visibility is
 //! compatible.
 #![deny(warnings)]
+#![allow(dead_code)]
 
 use mockall::*;
 

--- a/mockall/tests/mock_refmut_arguments.rs
+++ b/mockall/tests/mock_refmut_arguments.rs
@@ -2,11 +2,14 @@
 //! A struct with methods that take arguments by mutable reference.
 #![deny(warnings)]
 
+use std::mem;
+
 use mockall::*;
 
 mock!{
     Foo {
         fn foo(&self, x: &mut u32);
+        // This is almost never safe, but it should still work.
         fn bar(&self, y: &'static mut u32);
     }
 }
@@ -34,4 +37,16 @@ fn with() {
     let mut x = 42u32;
     mock.foo(&mut x);
     assert_eq!(5, x);
+}
+
+#[test]
+fn static_mut() {
+    let mut x: u32 = 5;
+    let mut mock = MockFoo::new();
+    mock.expect_bar()
+        .withf(|x| *x == 5)
+        .returning(|x| { *x = 42;} );
+    // Safe because mock leaves scope before x
+    unsafe { mock.bar(mem::transmute(&mut x)); }
+    assert_eq!(x, 42);
 }

--- a/mockall/tests/mock_struct_with_static_method.rs
+++ b/mockall/tests/mock_struct_with_static_method.rs
@@ -1,5 +1,6 @@
 // vim: tw=80
 #![deny(warnings)]
+#![allow(dead_code)]
 
 use mockall::*;
 use std::sync::Mutex;

--- a/mockall_derive/src/lib.rs
+++ b/mockall_derive/src/lib.rs
@@ -447,7 +447,7 @@ fn deselfify_args(
 {
     for arg in args.iter_mut() {
         if let FnArg::Typed(pt) = arg {
-            deselfify(&mut *pt.ty, actual, generics)
+            deselfify(pt.ty.as_mut(), actual, generics)
         }
     }
 }

--- a/mockall_derive/src/mock_function.rs
+++ b/mockall_derive/src/mock_function.rs
@@ -222,7 +222,7 @@ impl<'a> Builder<'a> {
                 false,
             ),
             ReturnType::Type(_, ref ty) => {
-                let mut output_ty = supersuperfy(&**ty, self.levels);
+                let mut output_ty = supersuperfy(ty, self.levels);
                 destrify(&mut output_ty);
                 let boxed = dedynify(&mut output_ty);
                 (output_ty, boxed)

--- a/mockall_derive/src/mockable_item.rs
+++ b/mockall_derive/src/mockable_item.rs
@@ -104,7 +104,7 @@ impl From<(Attrs, ItemForeignMod)> for MockableModule {
 
                         for arg in sig.inputs.iter_mut() {
                             if let FnArg::Typed(pt) = arg {
-                                *pt.ty = supersuperfy(&*pt.ty, 1);
+                                *pt.ty = supersuperfy(pt.ty.as_ref(), 1);
                             }
                         }
                         if let ReturnType::Type(_, ty) = &mut sig.output {


### PR DESCRIPTION
* clippy::explicit_auto_deref (but workaround clippy bug 9127)
* allow dead_code (in the tests)
* Remove some unneeded dead code in the tests

https://github.com/rust-lang/rust-clippy/issues/9127