### PR TITLE
Suppress "dead code" warnings when automocking a struct's private method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Fixed
 
+- Suppress "dead code" warnings when automocking a struct's private method.  It
+  might be used only by other public methods in the same struct.
+  ([#397](https://github.com/asomers/mockall/pull/397))
+
 - Fixed using Mockall when a function named `Ok` is in scope.  The `anyhow`
   crate, for example, creates a function by this name.
   ([#389](https://github.com/asomers/mockall/pull/389))

--- a/mockall/tests/automock_associated_const.rs
+++ b/mockall/tests/automock_associated_const.rs
@@ -32,7 +32,6 @@ trait Foo {
     }
 }
 
-#[allow(dead_code)]
 struct Bar {}
 
 #[automock]
@@ -40,7 +39,6 @@ impl Foo for Bar {
     const X: i32 = 42;
 }
 
-#[allow(dead_code)]
 pub struct Baz {}
 #[automock]
 impl Baz {

--- a/mockall/tests/automock_foreign_c.rs
+++ b/mockall/tests/automock_foreign_c.rs
@@ -15,8 +15,7 @@ mod ffi {
 }
 
 // Ensure we can still use the original mocked function
-#[allow(dead_code)]
-fn normal_usage() {
+pub fn normal_usage() {
     unsafe {
         ffi::foo(42);
     }

--- a/mockall/tests/automock_instrument.rs
+++ b/mockall/tests/automock_instrument.rs
@@ -2,7 +2,6 @@
 //! A trait that uses tracing::instrument should be automockable.  The mock
 //! method won't be instrumented, though.
 #![deny(warnings)]
-#![allow(dead_code)]
 
 use mockall::*;
 use tracing::instrument;

--- a/mockall/tests/automock_nonpub_methods.rs
+++ b/mockall/tests/automock_nonpub_methods.rs
@@ -1,0 +1,22 @@
+// vim: tw=80
+//! Using automock on a struct with private methods should not result in any
+//! "dead_code" warnings.  Such methods are often private helpers used only by
+//! other public methods.
+#[deny(dead_code)]
+
+pub mod mymod {
+    use mockall::automock;
+
+    pub struct Foo{}
+
+    #[automock]
+    impl Foo {
+        fn private_helper(&self) {}
+        fn static_private_helper() {}
+
+        pub fn pubfunc(&self) {
+            Self::static_private_helper();
+            self.private_helper()
+        }
+    }
+}

--- a/mockall/tests/mock_cfg.rs
+++ b/mockall/tests/mock_cfg.rs
@@ -1,7 +1,6 @@
 // vim: tw=80
 //! mock's methods and trait impls can be conditionally compiled
 #![deny(warnings)]
-#![allow(dead_code)]
 
 use mockall::*;
 

--- a/mockall/tests/mock_docs.rs
+++ b/mockall/tests/mock_docs.rs
@@ -1,7 +1,6 @@
 // vim: tw=80
 #![deny(missing_docs)]
 #![deny(warnings)]
-#![allow(dead_code)]
 
 use mockall::*;
 

--- a/mockall/tests/mock_generic_struct_with_generic_static_method.rs
+++ b/mockall/tests/mock_generic_struct_with_generic_static_method.rs
@@ -10,7 +10,6 @@ mock! {
         fn foo<Q: 'static>(t: T, q: Q) -> u64;
         // We must use a different method for every should_panic test, so the
         // shared mutex doesn't get poisoned.
-        #[allow(dead_code)]
         fn foo2<Q: 'static>(t: T, q: Q) -> u64;
         fn foo3<Q: 'static>(t: T, q: Q) -> u64;
     }

--- a/mockall/tests/mock_life0.rs
+++ b/mockall/tests/mock_life0.rs
@@ -2,7 +2,6 @@
 //! mock a method whose self parameter has an explicit lifetime
 //! https://github.com/asomers/mockall/issues/95
 #![deny(warnings)]
-#![allow(dead_code)]
 
 use mockall::*;
 

--- a/mockall/tests/mock_nonpub.rs
+++ b/mockall/tests/mock_nonpub.rs
@@ -2,7 +2,6 @@
 //! methods can use non-public types, as long as the object's visibility is
 //! compatible.
 #![deny(warnings)]
-#![allow(dead_code)]
 
 use mockall::*;
 

--- a/mockall/tests/mock_struct_with_static_method.rs
+++ b/mockall/tests/mock_struct_with_static_method.rs
@@ -1,6 +1,5 @@
 // vim: tw=80
 #![deny(warnings)]
-#![allow(dead_code)]
 
 use mockall::*;
 use std::sync::Mutex;


### PR DESCRIPTION
It might be used only by other public methods in the same struct.