### PR TITLE
Fix tests with latest nightly compiler and latest deps

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -13,7 +13,7 @@ common: &COMMON
 task:
   name: MSRV
   container:
-    image: rust:1.42.0
+    image: rust:1.45.0
   << : *COMMON
   before_cache_script: rm -rf $CARGO_HOME/registry/index
 

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -3,7 +3,7 @@ common: &COMMON
     RUSTFLAGS: -Dwarnings
     RUSTDOCFLAGS: -Dwarnings
   cargo_cache:
-    folder: $HOME/.cargo/registry
+    folder: $CARGO_HOME/registry
   build_script:
     - cargo build $CARGO_ARGS
   doc_script:
@@ -14,6 +14,9 @@ task:
   name: MSRV
   container:
     image: rust:1.45.0
+  env:
+    # CARGO_NET_GIT_FETCH_WITH_CLI is only necessary with Rust 1.45
+    CARGO_NET_GIT_FETCH_WITH_CLI: true
   << : *COMMON
   before_cache_script: rm -rf $CARGO_HOME/registry/index
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 
+## [ Unreleased ] - ReleaseDate
+
+## Changed
+
+- Raised MSRV to 1.45.0 because futures-task did.
+  ([#407](https://github.com/asomers/mockall/pull/407))
+
 ## [ 0.11.2 ] - 2022-07-24
 
 ## Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,2 +1,5 @@
 [workspace]
 members = ["mockall", "mockall_derive", "mockall_double"]
+
+[patch.crates-io]
+itertools = { git = "https://github.com/rust-itertools/itertools", rev = "d61d12e" }

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ See the [API docs](https://docs.rs/mockall) for more information.
 
 # Minimum Supported Rust Version (MSRV)
 
-Mockall is supported on Rust 1.42.0 and higher.  Mockall's MSRV will not be
+Mockall is supported on Rust 1.45.0 and higher.  Mockall's MSRV will not be
 changed in the future without bumping the major or minor version.
 
 # License

--- a/mockall/Cargo.toml
+++ b/mockall/Cargo.toml
@@ -9,6 +9,7 @@ categories = ["development-tools::testing"]
 keywords = ["mock", "mocking", "testing"]
 documentation = "https://docs.rs/mockall"
 edition = "2018"
+rust-version = "1.45"
 description = """
 A powerful mock object library for Rust.
 """

--- a/mockall/tests/automock_associated_const.rs
+++ b/mockall/tests/automock_associated_const.rs
@@ -32,7 +32,7 @@ trait Foo {
     }
 }
 
-struct Bar {}
+pub struct Bar {}
 
 #[automock]
 impl Foo for Bar {

--- a/mockall/tests/automock_gat.rs
+++ b/mockall/tests/automock_gat.rs
@@ -1,6 +1,5 @@
 #! vim: tw=80
 //! automock a trait with Generic Associated Types
-#![cfg_attr(feature = "nightly", feature(generic_associated_types))]
 #![deny(warnings)]
 
 use cfg_if::cfg_if;
@@ -14,7 +13,7 @@ cfg_if! {
         trait LendingIterator {
             type Item<'a> where Self: 'a;
 
-            // Clippy doesn't know that Mockall will need the liftime when it
+            // Clippy doesn't know that Mockall will need the lifetime when it
             // expands the macro.
             #[allow(clippy::needless_lifetimes)]
             fn next<'a>(&'a mut self) -> Option<Self::Item<'a>>;


### PR DESCRIPTION
* generic_associated_types is now stable on nightly
* futures-task raised its MSRV, so we must follow suit
* Fix an unused struct warning in one test with 1.45.0
* Add a rust-version field to Cargo.toml