### PR TITLE
add static method caveat to Modules documentation

### DIFF
--- a/mockall/src/lib.rs
+++ b/mockall/src/lib.rs
@@ -973,6 +973,9 @@
 //! "mock_xxx", if "xxx" is the original module's name.  You can also use
 //! `#[double]` to selectively import the mock module.
 //!
+//! Be careful!  Module functions are static and so have the same caveats as
+//! [static methods](#static-methods) described above.
+//!
 //! ```
 //! # use mockall::*;
 //! # use mockall_double::*;


### PR DESCRIPTION
If this warning was in the documentation it would have saved me a few hours.