### PR TITLE
Bump fragile dependency due to yanked older versions

### DIFF
--- a/mockall/Cargo.toml
+++ b/mockall/Cargo.toml
@@ -40,7 +40,7 @@ nightly = [
 [dependencies]
 cfg-if = "1.0"
 downcast = "0.11"
-fragile = "1.0"
+fragile = "2.0"
 lazy_static = "1.1"
 predicates = "2.0.1"
 predicates-tree = "1.0"


### PR DESCRIPTION
Older ^1.0 versions of [fragile](https://crates.io/crates/fragile/versions) have been yanked from crates.io, leading to the following error.

```
error: failed to select a version for the requirement `fragile = "^1.0"`
candidate versions found which didn't match: 2.0.0
location searched: crates.io index
required by package `mockall v0.11.2`
    ... which satisfies dependency `mockall = "^0.11.2"` of package `[redacted] v0.0.0 ([redacted])`
```