### PR TITLE
Revert "Patch itertools to fix the build on 1.45.0"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,2 @@
 [workspace]
 members = ["mockall", "mockall_derive", "mockall_double"]
-
-[patch.crates-io]
-itertools = { git = "https://github.com/rust-itertools/itertools", rev = "d61d12e" }


### PR DESCRIPTION
This reverts commit a147af4cee2282b1dc793b7cecbcc7043d73b11e.

It's no longer needed now that itertools-1.15.0 is released.