### PR TITLE
Correctly process the concretize attribute within cfg_attr

### DIFF
--- a/mockall/tests/cfg_attr_concretize.rs
+++ b/mockall/tests/cfg_attr_concretize.rs
@@ -1,0 +1,26 @@
+// vim: tw=80
+//! #[concretize] can be used inside of #[cfg_attr()]`
+#![deny(warnings)]
+
+use std::path::{Path, PathBuf};
+
+use mockall::{automock, concretize};
+
+#[automock]
+trait Foo {
+    #[cfg_attr(not(target_os = "ia64-unknown-multics"), concretize)]
+    fn foo<P: AsRef<Path>>(&self, p: P);
+}
+
+
+#[test]
+fn withf() {
+    let mut foo = MockFoo::new();
+    foo.expect_foo()
+        .withf(|p| p.as_ref() == Path::new("/tmp"))
+        .times(3)
+        .return_const(());
+    foo.foo(Path::new("/tmp"));
+    foo.foo(PathBuf::from(Path::new("/tmp")));
+    foo.foo("/tmp");
+}

--- a/mockall_derive/src/lib.rs
+++ b/mockall_derive/src/lib.rs
@@ -754,6 +754,11 @@ impl<'a> AttrFormatter<'a> {
                 } else if *i.as_ref().unwrap() == "concretize" {
                     // Internally used attribute.  Never emit.
                     false
+                } else if *i.as_ref().unwrap() == "cfg_attr" &&
+                    attr.tokens.to_string().contains("concretize")
+                {
+                    // Internally used attribute.  Never emit.
+                    false
                 } else {
                     true
                 }

--- a/mockall_derive/src/mock_function.rs
+++ b/mockall_derive/src/mock_function.rs
@@ -168,7 +168,13 @@ impl<'a> Builder<'a> {
             .any(|attr|
                 attr.path.segments.last()
                 .map(|ps| ps.ident == "concretize")
-                .unwrap_or(false)
+                .unwrap_or(false) ||
+                (
+                    attr.path.segments.last()
+                    .map(|ps| ps.ident == "cfg_attr")
+                    .unwrap_or(false) &&
+                    attr.tokens.to_string().contains("concretize")
+                )
             ) {
                 self.concretize = true;
             }


### PR DESCRIPTION
The concretize attribute isn't processed as a normal Rust attribute. Instead, Mockall processes it as text.  So we need to process any cfg_attr directive ourselves.  Rather than attempt to evaluate the conditional, just assume that it's true.  By far the most common use case will be `cfg_attr(test, concretize)`.

Fixes #427