### PR TITLE
Suppress some needless_lifetimes warnings from Clippy

### DIFF
--- a/mockall/tests/automock_generic_future_with_where_clause.rs
+++ b/mockall/tests/automock_generic_future_with_where_clause.rs
@@ -5,9 +5,9 @@
 //!
 //! Mockall must not emit the where clause for the method's Expectation.
 #![deny(warnings)]
+#![allow(clippy::needless_lifetimes)]
 
 use mockall::*;
-//use std::task::Context;
 
 struct Foo<T: 'static, V: 'static>((T, V));
 trait MyTrait {

--- a/mockall/tests/automock_where_self.rs
+++ b/mockall/tests/automock_where_self.rs
@@ -2,6 +2,7 @@
 //! Methods with a "where Self: ..." where clause should be mocked as concrete,
 //! not generic.
 #![deny(warnings)]
+#![allow(clippy::needless_lifetimes)]
 
 // Enclose the mocked trait within a non-public module.  With some versions of
 // rustc, that causes "unused method" errors for the generic code, but not the


### PR DESCRIPTION
Yes, they're needless, but they're there to exercise Mockall's parsing.