### PR TITLE
Always drop static methods' Expectations during Drop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- Static methods' expectations will now be cleared during a panic.
+  ([#443](https://github.com/asomers/mockall/pull/443))
+
 - Methods with a `where Self: ...` clause will now be mocked like concrete
   methods, not generic ones.  Among other effects, this prevents "unused method
   expect" warnings from the latest nightly compiler.

--- a/mockall/tests/clear_expectations_on_panic.rs
+++ b/mockall/tests/clear_expectations_on_panic.rs
@@ -1,0 +1,33 @@
+// vim: tw=80
+//! Static methods' expectations should be dropped during panic.
+//!
+//! https://github.com/asomers/mockall/issues/442
+#![deny(warnings)]
+
+use std::panic;
+
+use mockall::*;
+
+#[automock]
+pub trait Foo {
+    fn foo() -> i32;
+}
+
+#[test]
+fn drop_expectations_on_panic() {
+    panic::catch_unwind(|| {
+        let ctx = MockFoo::foo_context();
+        ctx.expect()
+            .times(1)
+            .return_const(42);
+        panic!("Panicking!");
+    }).unwrap_err();
+
+    // The previously set expectation should've been cleared during the panic,
+    // so we must set a new one.
+    let ctx = MockFoo::foo_context();
+    ctx.expect()
+        .times(1)
+        .return_const(42);
+    assert_eq!(42, MockFoo::foo());
+}

--- a/mockall_derive/src/mock_function.rs
+++ b/mockall_derive/src/mock_function.rs
@@ -1574,9 +1574,7 @@ impl<'a> ToTokens for Context<'a> {
             }
             impl #ty_ig Drop for Context #ty_tg #ty_wc {
                 fn drop(&mut self) {
-                    if !std::thread::panicking() {
-                        Self::do_checkpoint()
-                    }
+                    Self::do_checkpoint()
                 }
             }
         ).to_tokens(tokens);


### PR DESCRIPTION
Even if a panic is in-progress.  Originally we didn't drop them during panic, for fear of double-panicing.  But there is already protection from double-panic in Common::drop.  Not clearing expectations during a panic can cause surprising failures in one test case after a different test case panics.

Fixes #442