### PR TITLE
Use 2021 edition throughout.

### DIFF
--- a/mockall/Cargo.toml
+++ b/mockall/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/asomers/mockall"
 categories = ["development-tools::testing"]
 keywords = ["mock", "mocking", "testing"]
 documentation = "https://docs.rs/mockall"
-edition = "2018"
+edition = "2021"
 rust-version = "1.60"
 description = """
 A powerful mock object library for Rust.

--- a/mockall/src/lib.rs
+++ b/mockall/src/lib.rs
@@ -58,7 +58,7 @@
 //!     fn foo(&self, x: u32) -> u32;
 //! }
 //!
-//! fn call_with_four(x: &MyTrait) -> u32 {
+//! fn call_with_four(x: &dyn MyTrait) -> u32 {
 //!     x.foo(4)
 //! }
 //!

--- a/mockall_derive/Cargo.toml
+++ b/mockall_derive/Cargo.toml
@@ -7,7 +7,7 @@ repository = "https://github.com/asomers/mockall"
 categories = ["development-tools::testing"]
 keywords = ["mock", "mocking", "testing"]
 documentation = "https://docs.rs/mockall_derive"
-edition = "2018"
+edition = "2021"
 description = """
 Procedural macros for Mockall
 """

--- a/mockall_derive/src/lib.rs
+++ b/mockall_derive/src/lib.rs
@@ -50,7 +50,7 @@ cfg_if! {
         }
     } else {
         fn compile_error(_span: Span, msg: &str) {
-            panic!("{}.  More information may be available when mockall is built with the \"nightly\" feature.", msg);
+            panic!("{msg}.  More information may be available when mockall is built with the \"nightly\" feature.");
         }
     }
 }

--- a/mockall_derive/src/mock_function.rs
+++ b/mockall_derive/src/mock_function.rs
@@ -521,7 +521,7 @@ impl MockFunction {
                          * generic parameters with UnwindSafe
                          */
                         /* std::panic::catch_unwind(|| */
-                        __mockall_guard.#call#tbf(#(#call_exprs,)*)
+                        __mockall_guard.#call #tbf(#(#call_exprs,)*)
                         /*)*/
                     }.expect(&no_match_msg)
                 }
@@ -533,7 +533,7 @@ impl MockFunction {
                 #dead_code
                 #vis #sig {
                     let no_match_msg = #no_match_msg;
-                    #deref self.#substruct_obj #name.#call#tbf(#(#call_exprs,)*)
+                    #deref self.#substruct_obj #name.#call #tbf(#(#call_exprs,)*)
                     .expect(&no_match_msg)
                 }
 
@@ -663,7 +663,7 @@ impl MockFunction {
                -> &mut #modname::#expectation_obj
                #wc
             {
-                self.#substruct_obj #name.expect#tbf()
+                self.#substruct_obj #name.expect #tbf()
             }
         )
     }

--- a/mockall_double/Cargo.toml
+++ b/mockall_double/Cargo.toml
@@ -7,7 +7,7 @@ repository = "https://github.com/asomers/mockall"
 categories = ["development-tools::testing"]
 keywords = ["mock", "mocking", "testing"]
 documentation = "https://docs.rs/mockall_double"
-edition = "2018"
+edition = "2021"
 description = """
 Test double adapter for Mockall
 """

--- a/mockall_double/src/lib.rs
+++ b/mockall_double/src/lib.rs
@@ -31,7 +31,7 @@ cfg_if! {
         }
     } else {
         fn compile_error(_span: Span, msg: &str) {
-            panic!("{}.  More information may be available when mockall_double is built with the \"nightly\" feature.", msg);
+            panic!("{msg}.  More information may be available when mockall_double is built with the \"nightly\" feature.");
         }
     }
 }


### PR DESCRIPTION
It's especially useful to have the examples use 2021 edition, because that's what most new users will be using.