### PR TITLE
Fix clippy

### DIFF
--- a/mockall/tests/automock_generic_method_without_generic_args_or_return.rs
+++ b/mockall/tests/automock_generic_method_without_generic_args_or_return.rs
@@ -10,10 +10,12 @@ pub struct Foo{}
 
 #[automock]
 impl Foo {
+    #[allow(clippy::extra_unused_type_parameters)]
     pub fn foo<T: 'static>(&self) -> i32 {
         unimplemented!()
     }
     /// A static method
+    #[allow(clippy::extra_unused_type_parameters)]
     pub fn bar<T: 'static>() -> i32 {
         unimplemented!()
     }


### PR DESCRIPTION
Suppress the extra_unused_type_parameters in a test, where it's intentional.