### PR TITLE
Clippy cleanup

### DIFF
--- a/mockall/tests/automock_generic_future.rs
+++ b/mockall/tests/automock_generic_future.rs
@@ -5,6 +5,7 @@
 //! poll method must not be treated as a generic method.
 #![deny(warnings)]
 
+use futures::executor::block_on;
 use mockall::*;
 use std::{
     future::Future,
@@ -29,8 +30,7 @@ impl<T: 'static> Future for Foo<T> {
 fn ready() {
     let mut mock = MockFoo::<u32>::new();
     mock.expect_poll()
+        .once()
         .return_const(Poll::Ready(()));
-    let _r = async {
-        mock.await
-    };
+    block_on(mock);
 }


### PR DESCRIPTION
Quiet the new redundant_async_block lint.  Also, ensure that the mock function actually gets called in the automock_generic_future test.