### PR TITLE
Changed example to use a C function available also on Windows

### DIFF
--- a/mockall/examples/ffi.rs
+++ b/mockall/examples/ffi.rs
@@ -1,7 +1,6 @@
 // vim: tw=80
 //! An example of unit testing involving mocked FFI functions
 
-use std::ptr;
 #[cfg(test)]
 use mockall::automock;
 use mockall_double::double;
@@ -9,26 +8,27 @@ use mockall_double::double;
 #[cfg_attr(test, automock)]
 pub mod mockable_ffi {
     extern "C" {
-        pub fn time(timer: *mut u64) -> u64;
+        pub fn abs(i: i32) -> i32;
     }
 }
 
 #[double]
 use mockable_ffi as ffi;
 
-fn time() -> u64 {
-    unsafe { ffi::time(ptr::null_mut()) }
+fn abs(i: i32) -> i32 {
+    unsafe { ffi::abs(i) }
 }
 
 fn main() {
-    println!("Seconds since epoch: {}", time() );
+    let i: i32 = -42;
+    println!("abs({}) = {}", i, abs(i) );
 }
 
 
 #[test]
 fn time_test() {
-    let ctx = ffi::time_context();
+    let ctx = ffi::abs_context();
     ctx.expect()
-        .return_const(42u64);
-    time();
+        .return_const(42);
+    assert_eq!(42, abs(-42))
 }

--- a/mockall/examples/ffi.rs
+++ b/mockall/examples/ffi.rs
@@ -9,7 +9,7 @@ use mockall_double::double;
 #[cfg_attr(test, automock)]
 pub mod mockable_ffi {
     extern "C" {
-        pub fn time(timer: *const u64) -> u64;
+        pub fn time(timer: *mut u64) -> u64;
     }
 }
 
@@ -17,7 +17,7 @@ pub mod mockable_ffi {
 use mockable_ffi as ffi;
 
 fn time() -> u64 {
-    unsafe { ffi::time(ptr::null()) }
+    unsafe { ffi::time(ptr::null_mut()) }
 }
 
 fn main() {
@@ -27,13 +27,8 @@ fn main() {
 
 #[test]
 fn time_test() {
-    let seconds_from_epoch = std::time::SystemTime::now()
-        .duration_since(std::time::SystemTime::UNIX_EPOCH)
-        .unwrap_or(std::time::Duration::from_secs(0))
-        .as_secs();
-
     let ctx = ffi::time_context();
     ctx.expect()
-        .return_const(seconds_from_epoch);
+        .return_const(42u64);
     time();
 }

--- a/mockall/examples/ffi.rs
+++ b/mockall/examples/ffi.rs
@@ -5,7 +5,6 @@ use std::ptr;
 #[cfg(test)]
 use mockall::automock;
 use mockall_double::double;
-use std::time::{Duration, SystemTime};
 
 #[cfg_attr(test, automock)]
 pub mod mockable_ffi {
@@ -28,9 +27,9 @@ fn main() {
 
 #[test]
 fn time_test() {
-    let seconds_from_epoch = SystemTime::now()
-        .duration_since(SystemTime::UNIX_EPOCH)
-        .unwrap_or(Duration::from_secs(0))
+    let seconds_from_epoch = std::time::SystemTime::now()
+        .duration_since(std::time::SystemTime::UNIX_EPOCH)
+        .unwrap_or(std::time::Duration::from_secs(0))
         .as_secs();
 
     let ctx = ffi::time_context();

--- a/mockall/examples/ffi.rs
+++ b/mockall/examples/ffi.rs
@@ -1,35 +1,40 @@
 // vim: tw=80
 //! An example of unit testing involving mocked FFI functions
 
-#![cfg(unix)]
-
+use std::ptr;
 #[cfg(test)]
 use mockall::automock;
 use mockall_double::double;
+use std::time::{Duration, SystemTime};
 
 #[cfg_attr(test, automock)]
 pub mod mockable_ffi {
     extern "C" {
-        pub fn getuid() -> u32;
+        pub fn time(timer: *const u64) -> u64;
     }
 }
 
 #[double]
 use mockable_ffi as ffi;
 
-fn getuid() -> u32 {
-    unsafe { ffi::getuid() }
+fn time() -> u64 {
+    unsafe { ffi::time(ptr::null()) }
 }
 
 fn main() {
-    println!("My uid is {}", getuid() );
+    println!("Seconds since epoch: {}", time() );
 }
 
 
 #[test]
-fn getuid_test() {
-    let ctx = ffi::getuid_context();
+fn time_test() {
+    let seconds_from_epoch = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap_or(Duration::from_secs(0))
+        .as_secs();
+
+    let ctx = ffi::time_context();
     ctx.expect()
-        .return_const(42u32);
-    getuid();
+        .return_const(seconds_from_epoch);
+    time();
 }


### PR DESCRIPTION
`getuid()` is a clib function that's only available on UNIX systems, this pull request uses the `time()` function that's also available on Windows.

Now when running `cargo test` on Windows the command doesn't fail with error message:
```
error[E0601]: `main` function not found in crate `ffi`
  --> mockall\examples\ffi.rs:35:2
   |
35 | }
   |  ^ consider adding a `main` function to `mockall\examples\ffi.rs`
```