### PR TITLE
Fixing compatibility with syn-2.0.9

### DIFF
--- a/mockall_derive/Cargo.toml
+++ b/mockall_derive/Cargo.toml
@@ -30,7 +30,7 @@ nightly_derive = ["proc-macro2/nightly"]
 cfg-if = "1.0"
 proc-macro2 = "1.0"
 quote = "1.0"
-syn = { version = "2.0", features = ["extra-traits", "full"] }
+syn = { version = "2.0.9", features = ["extra-traits", "full"] }
 
 [dev-dependencies]
 pretty_assertions = "1.3"

--- a/mockall_derive/src/lib.rs
+++ b/mockall_derive/src/lib.rs
@@ -1688,10 +1688,10 @@ mod dewhereselfify {
     #[test]
     fn lifetime() {
         let mut meth: ImplItemFn = parse2(quote!(
-                fn foo<'a>(&self) where 'a: 'static, Self: Sized;
+                fn foo<'a>(&self) where 'a: 'static, Self: Sized {}
         )).unwrap();
         let expected: ImplItemFn = parse2(quote!(
-                fn foo<'a>(&self) where 'a: 'static;
+                fn foo<'a>(&self) where 'a: 'static {}
         )).unwrap();
         dewhereselfify(&mut meth.sig.generics);
         assert_eq!(meth, expected);
@@ -1700,10 +1700,10 @@ mod dewhereselfify {
     #[test]
     fn normal_method() {
         let mut meth: ImplItemFn = parse2(quote!(
-                fn foo(&self) where Self: Sized;
+                fn foo(&self) where Self: Sized {}
         )).unwrap();
         let expected: ImplItemFn = parse2(quote!(
-                fn foo(&self);
+                fn foo(&self) {}
         )).unwrap();
         dewhereselfify(&mut meth.sig.generics);
         assert_eq!(meth, expected);
@@ -1712,10 +1712,10 @@ mod dewhereselfify {
     #[test]
     fn with_real_generics() {
         let mut meth: ImplItemFn = parse2(quote!(
-                fn foo<T>(&self, t: T) where Self: Sized, T: Copy;
+                fn foo<T>(&self, t: T) where Self: Sized, T: Copy {}
         )).unwrap();
         let expected: ImplItemFn = parse2(quote!(
-                fn foo<T>(&self, t: T) where T: Copy;
+                fn foo<T>(&self, t: T) where T: Copy {}
         )).unwrap();
         dewhereselfify(&mut meth.sig.generics);
         assert_eq!(meth, expected);


### PR DESCRIPTION
This version of syn is more picky about parsing ItemImplFn.  Previously it would accept "pub fn foo(&self);" and consider the ";" to be the function's Block.  But now it (technically correctly) doesn't recognize that as a valid ItemImplFn.  So instead we'll have to parse that as a combination of a Visibility and a TraitItemFn.