### PR TITLE
Add v0.11.3 notes to CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,12 +31,17 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Static methods' expectations will now be cleared during a panic.
   ([#443](https://github.com/asomers/mockall/pull/443))
 
+- Methods with unknown size type bounds can now be mocked.
+  ([#421](https://github.com/asomers/mockall/pull/421))
+
+## [ 0.11.3 ] - 2022-10-18
+
+### Fixed
+
 - Methods with a `where Self: ...` clause will now be mocked like concrete
   methods, not generic ones.  Among other effects, this prevents "unused method
   expect" warnings from the latest nightly compiler.
   ([#415](https://github.com/asomers/mockall/pull/415))
-- Methods with unknown size type bounds can now be mocked.
-  ([#421](https://github.com/asomers/mockall/pull/421))
 
 ## [ 0.11.2 ] - 2022-07-24
 


### PR DESCRIPTION
The CHANGELOG was already correct in the r0.11 branch, but not on master.

[skip ci]