### PR TITLE
Fix mock! with pub functions that have attrs with syn-2.0.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,12 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Better "No matching expectation found" messages on stable.
   ([#425](https://github.com/asomers/mockall/pull/425))
 
+### Fixed
+
+- Fixed mocking non-private inherent methods that have attributes with syn
+  version 2.0.9 and later.
+  ([#485](https://github.com/asomers/mockall/pull/485))
+
 ### Removed
 
 - Removed syntax deprecated since 0.9.0: using `#[automock]` directly on an

--- a/mockall/tests/mock_cfg.rs
+++ b/mockall/tests/mock_cfg.rs
@@ -18,9 +18,9 @@ trait Beez {
 mock! {
     pub Foo {
         #[cfg(feature = "nightly")]
-        fn foo(&self);
+        pub fn foo(&self);
         #[cfg(not(feature = "nightly"))]
-        fn foo(&self, x: i32) -> i32;
+        pub fn foo(&self, x: i32) -> i32;
     }
     #[cfg(feature = "nightly")]
     impl Beez for Foo {

--- a/mockall/tests/mock_concretize.rs
+++ b/mockall/tests/mock_concretize.rs
@@ -11,23 +11,33 @@ impl<Q, T> AsRefMut<T> for Q where Q: AsRef<T> + AsMut<T>, T: ?Sized {}
 
 mock! {
     Foo {
+        /// Base concretized function
         #[mockall::concretize]
         fn foo<P: AsRef<std::path::Path>>(&self, x: P);
 
+        /// With a where clause
         #[mockall::concretize]
         fn boom<P>(&self, x: P) where P: AsRef<std::path::Path>;
 
+        /// Static function
         #[mockall::concretize]
         fn bang<P: AsRef<std::path::Path>>(x: P);
 
+        /// Reference argument
         #[mockall::concretize]
         fn boomref<P: AsRef<std::path::Path>>(&self, x: &P);
 
+        /// Mutable reference argument
         #[mockall::concretize]
         fn boom_mutref<T: AsRefMut<str>>(&self, x: &mut T);
 
+        /// Slice argument
         #[mockall::concretize]
         fn boomv<P>(&self, x: &[P]) where P: AsRef<std::path::Path>;
+
+        /// Public visiblity
+        #[mockall::concretize]
+        pub fn foopub<P: AsRef<std::path::Path>>(&self, x: P);
     }
 }
 


### PR DESCRIPTION
Starting with syn 2.0.9, attempting to use an attribute on a non-private method would fail with a syntax error "expected fn".

Also, rename tim2iif to tif2iif.  This should've been part of the syn-2.0.0 conversion.