### PR TITLE
Suppress clippy::too_many_arguments warnings in the generated code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   version 2.0.9 and later.
   ([#485](https://github.com/asomers/mockall/pull/485))
 
+- Suppress `clippy::too_many_arguments` warnings in the generated code.  This
+  is most useful when mocking static functions with exactly 7 arguments.
+  ([#487](https://github.com/asomers/mockall/pull/487))
+
 ### Removed
 
 - Removed syntax deprecated since 0.9.0: using `#[automock]` directly on an

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,2 +1,6 @@
 # I use a lot of dumb names in the tests
 disallowed-names = []
+
+# Default is 7.  Lock it there, so a change to the default value doesn't break
+# the automock_seven_args test.
+too-many-arguments-threshold = 7

--- a/mockall/tests/automock_seven_args.rs
+++ b/mockall/tests/automock_seven_args.rs
@@ -1,0 +1,22 @@
+// vim: tw=80
+//! When mocking static functions just at the threshold of Clippy's type
+//! complexity limit, no warnings should be emitted regarding the generated
+//! code.
+#![deny(warnings)]
+
+use mockall::automock;
+
+#[automock]
+trait ManyArgs {
+    fn foo(_a0: u8, _a1: u8, _a2: u8, _a3: u8, _a4: u8, _a5: u8, _a6: u8);
+}
+
+#[test]
+fn static_method_returning() {
+    let ctx = MockManyArgs::foo_context();
+    ctx.expect()
+        .returning(|_, _, _, _, _, _, _|  ());
+    MockManyArgs::foo(0, 0, 0, 0, 0, 0, 0);
+}
+
+

--- a/mockall_derive/src/mock_function.rs
+++ b/mockall_derive/src/mock_function.rs
@@ -816,6 +816,7 @@ impl MockFunction {
         quote!(
             #(#attrs)*
             #[allow(missing_docs)]
+            #[allow(clippy::too_many_arguments)]
             pub mod #inner_mod_ident {
                 use super::*;
                 use ::mockall::CaseTreeExt;


### PR DESCRIPTION
This warning has always been possible, but it was particularly annoying when the user mocks a static function with seven arguments.  Because in that case, some of the generated code will have eight arguments, triggering the warning even though the original code did not.

Fixes #480