### PR TITLE
Work better with FFI functions that use `link_name`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   is most useful when mocking static functions with exactly 7 arguments.
   ([#487](https://github.com/asomers/mockall/pull/487))
 
+- Fixed `unused_attributes` warnings in the generated code when mocking FFI
+  functions that use `#[link_name]`.
+  ([#503](https://github.com/asomers/mockall/pull/503))
+
 ### Removed
 
 - Removed syntax deprecated since 0.9.0: using `#[automock]` directly on an

--- a/mockall/tests/link_name.rs
+++ b/mockall/tests/link_name.rs
@@ -1,0 +1,19 @@
+// vim: tw=80
+#![deny(warnings)]
+
+use mockall::*;
+
+#[automock]
+pub mod ffi {
+    extern "C" {
+        #[link_name = "foo__extern"]
+        pub fn foo() -> u32;
+    }
+}
+
+#[test]
+fn return_const() {
+    let ctx = mock_ffi::foo_context();
+    ctx.expect().return_const(42u32);
+    assert_eq!(42, unsafe{mock_ffi::foo()});
+}

--- a/mockall_derive/src/lib.rs
+++ b/mockall_derive/src/lib.rs
@@ -779,6 +779,10 @@ impl<'a> AttrFormatter<'a> {
                     // ignore this attribute.
                     // https://docs.rs/tracing/0.1.23/tracing/attr.instrument.html
                     false
+                } else if *i.as_ref().unwrap() == "link_name" {
+                    // This shows up sometimes when mocking ffi functions.  We
+                    // must not emit it on anything that isn't an ffi definition
+                    false
                 } else {
                     true
                 }


### PR DESCRIPTION
Avoid emitting this attribute in the generated code, which causes `unused_attribute` warnings.

Fixes #502