### PR TITLE
The ABI and attr properties of the mocked functions have been changed. Associated with issiue 501.

### DIFF
--- a/mockall_derive/src/mock_item.rs
+++ b/mockall_derive/src/mock_item.rs
@@ -85,6 +85,15 @@ impl From<MockableModule> for MockItemModule {
                             // foreign functions should be unsafe too, to
                             // prevent "warning: unused unsafe" messages.
                             f.sig.unsafety = Some(Token![unsafe](f.span()));
+
+                            // Set the ABI to match the ForeignMod's ABI
+                            // for proper function linkage with external code.
+                            f.sig.abi = Some(ifm.abi.clone());
+
+                            // Add #[no_mangle] attribute to preserve the function name
+                            // as-is, without mangling, for compatibility with C functions.
+                            f.attrs.push(parse_quote! {#[no_mangle]});
+
                             let mf = mock_function::Builder::new(&f.sig, &f.vis)
                                 .attrs(&f.attrs)
                                 .parent(&mock_ident)


### PR DESCRIPTION
I was encountering an issue with mocking a ffi variadic function. I checked with cargo expand and i saw the reason behind this issue was that the mock function was lacking the extern "C". I checked mockall source code and i saw the ABI of function signatures was not set in the condition of "Item::ForeignMod" in the "impl From<MockableModule> for MockItemModule" code block in mock_item.rs file. These functions were under "extern "C" and I thought the mocks of these functions should be like this so I made the change.

My primary goal was to write unit tests in Rust for C source code, which required the mock functions to be compatible with C. For this reason, I added the no_mangle attribute. However, it's possible that a few adjustments are needed in the code, as I am not very familiar with Rust. 

r please @asomers 