### PR TITLE
Added C variadic test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,6 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   be disabled, so the mock function will be callable from external code. For
   example, from C functions.
   ([#504](https://github.com/asomers/mockall/pull/504))
-- Added a test file showing how 'c variadic' functions can be mocked and tested.
-  This requires the `nightly` feature.
-  ([#508](https://github.com/asomers/mockall/pull/508))
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   be disabled, so the mock function will be callable from external code. For
   example, from C functions.
   ([#504](https://github.com/asomers/mockall/pull/504))
+- Added a test file showing how 'c variadic' functions can be mocked and tested.
+  This requires the `nightly` feature.
+  ([#508](https://github.com/asomers/mockall/pull/508))
 
 ### Changed
 

--- a/mockall/tests/automock_foreign_c_variadic.rs
+++ b/mockall/tests/automock_foreign_c_variadic.rs
@@ -1,0 +1,23 @@
+// vim: tw=80
+#![cfg_attr(feature = "nightly", feature(c_variadic))]
+#![deny(warnings)]
+
+#[cfg(feature = "nightly")]
+use mockall::*;
+
+#[automock]
+#[cfg(feature = "nightly")]
+mod ffi {
+    extern "C" {
+        #[allow(dead_code)]
+        pub(super) fn foo(x: i32, y: i32, ...) -> i32;
+    }
+}
+
+#[test]
+#[cfg(feature = "nightly")]
+fn mocked_c_variadic() {
+    let ctx = mock_ffi::foo_context();
+    ctx.expect().returning(|x, y| x * y);
+    assert_eq!(6, unsafe{mock_ffi::foo(2, 3, 1, 4, 1)});
+}

--- a/mockall/tests/automock_foreign_c_variadic.rs
+++ b/mockall/tests/automock_foreign_c_variadic.rs
@@ -7,10 +7,9 @@ use mockall::*;
 
 #[automock]
 #[cfg(feature = "nightly")]
-mod ffi {
+pub mod ffi {
     extern "C" {
-        #[allow(dead_code)]
-        pub(super) fn foo(x: i32, y: i32, ...) -> i32;
+        pub fn foo(x: i32, y: i32, ...) -> i32;
     }
 }
 


### PR DESCRIPTION
Add Test Scenario for C Variadics Using Mockall

This PR adds a test file to address the mocking of 'c_variadic' functions. However, please note that testing the variadic parameters themselves is not feasible due to their dynamic nature.

r @asomers 