### PR TITLE
Fix a double-panic when static methods' expectations are oversatisfied

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   functions that use `#[link_name]`.
   ([#503](https://github.com/asomers/mockall/pull/503))
 
+- Fix a panic during Drop for static methods.  One way to trigger it is by
+  calling the method more times than is allowed by a `.times()` constraint.
+  Another way would be to explicitly panic during the `.returning` method.
+  ([#516](https://github.com/asomers/mockall/pull/516))
+
 ### Removed
 
 - Removed syntax deprecated since 0.9.0: using `#[automock]` directly on an

--- a/mockall/tests/clear_expectations_on_panic.rs
+++ b/mockall/tests/clear_expectations_on_panic.rs
@@ -11,16 +11,16 @@ use mockall::*;
 #[automock]
 pub trait Foo {
     fn foo() -> i32;
+    fn bar() -> i32;
 }
 
 #[test]
-fn drop_expectations_on_panic() {
+fn too_few_calls() {
     panic::catch_unwind(|| {
         let ctx = MockFoo::foo_context();
         ctx.expect()
             .times(1)
             .return_const(42);
-        panic!("Panicking!");
     }).unwrap_err();
 
     // The previously set expectation should've been cleared during the panic,
@@ -30,4 +30,21 @@ fn drop_expectations_on_panic() {
         .times(1)
         .return_const(42);
     assert_eq!(42, MockFoo::foo());
+}
+
+// We shouldn't panic during drop in this case.  Regression test for
+// https://github.com/asomers/mockall/issues/491
+#[should_panic(expected = "called `Result::unwrap()` on an `Err` value: PoisonError { .. }")]
+#[test]
+fn too_many_calls() {
+    panic::catch_unwind(|| {
+        let ctx = MockFoo::bar_context();
+        ctx.expect()
+            .times(0);
+        MockFoo::bar();
+    }).unwrap_err();
+
+    // This line will panic with a PoisonError, at least until issue #515 is
+    // complete.  
+    let _ctx = MockFoo::bar_context();
 }


### PR DESCRIPTION
PR #443 ensured that static methods' expectations would be cleared on Drop.  But it was only tested for methods that paniced due to too few method calls.  For methods with too many calls it actually introduced a double-panic.  Double panics are bad; they lead to processes getting SIGABRT.  This was a regression in Mockall 0.11.4.

Fixes #491