### PR TITLE
Remove default features from predicates dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   `extern "C"` block, and using `trait Foo {}` syntax inside of `mock!`.
   ([#476](https://github.com/asomers/mockall/pull/476))
 
+- Removed default features from `predicates` dependency. Reexports no longer
+  include `difflib`, `normalize-line-endings`, `regex` and `float-cmp` features.
+  ([#517](https://github.com/asomers/mockall/pull/517))
+
 ## [ 0.11.4 ] - 2023-03-26
 
 ### Fixed

--- a/mockall/Cargo.toml
+++ b/mockall/Cargo.toml
@@ -42,7 +42,7 @@ cfg-if = "1.0"
 downcast = "0.11"
 fragile = "2.0"
 lazy_static = "1.1"
-predicates = "3.0.0"
+predicates = { version = "3.0.0", default-features = false }
 predicates-tree = "1.0"
 mockall_derive = { version = "=0.11.2", path = "../mockall_derive" }
 


### PR DESCRIPTION
Predicates has default optional features this crate doesn't use. These features even include regex, which is a heavy dependency. This PR should slightly improve compile times for crates using mockall