### PR TITLE
Quiet clippy::needless_raw_string_hashes

### DIFF
--- a/mockall_derive/src/lib.rs
+++ b/mockall_derive/src/lib.rs
@@ -1335,7 +1335,7 @@ mod mock {
 
     #[test]
     fn inherent_method_visibility() {
-        let code = r#"
+        let code = "
             Foo {
                 fn foo(&self);
                 pub fn bar(&self);
@@ -1343,7 +1343,7 @@ mod mock {
                 pub(super) fn bean(&self);
                 pub(in crate::outer) fn boom(&self);
             }
-        "#;
+        ";
         let ts = proc_macro2::TokenStream::from_str(code).unwrap();
         let output = do_mock(ts).to_string();
         assert_not_contains(&output, quote!(pub fn foo));
@@ -1364,7 +1364,7 @@ mod mock {
 
     #[test]
     fn specific_impl() {
-        let code = r#"
+        let code = "
             pub Foo<T: 'static> {}
             impl Bar for Foo<u32> {
                 fn bar(&self);
@@ -1372,7 +1372,7 @@ mod mock {
             impl Bar for Foo<i32> {
                 fn bar(&self);
             }
-        "#;
+        ";
         let ts = proc_macro2::TokenStream::from_str(code).unwrap();
         let output = do_mock(ts).to_string();
         assert_contains(&output, quote!(impl Bar for MockFoo<u32>));
@@ -1401,12 +1401,12 @@ mod automock {
 
     #[test]
     fn doc_comments() {
-        let code = r#"
+        let code = "
             mod foo {
                 /// Function docs
                 pub fn bar() { unimplemented!() }
             }
-        "#;
+        ";
         let ts = proc_macro2::TokenStream::from_str(code).unwrap();
         let attrs_ts = proc_macro2::TokenStream::from_str("").unwrap();
         let output = do_automock(attrs_ts, ts).to_string();
@@ -1415,14 +1415,14 @@ mod automock {
 
     #[test]
     fn method_visibility() {
-        let code = r#"
+        let code = "
         impl Foo {
             fn foo(&self) {}
             pub fn bar(&self) {}
             pub(super) fn baz(&self) {}
             pub(crate) fn bang(&self) {}
             pub(in super::x) fn bean(&self) {}
-        }"#;
+        }";
         let ts = proc_macro2::TokenStream::from_str(code).unwrap();
         let attrs_ts = proc_macro2::TokenStream::from_str("").unwrap();
         let output = do_automock(attrs_ts, ts).to_string();
@@ -1443,7 +1443,7 @@ mod automock {
     #[test]
     #[should_panic(expected = "can only mock inline modules")]
     fn external_module() {
-        let code = r#"mod foo;"#;
+        let code = "mod foo;";
         let ts = proc_macro2::TokenStream::from_str(code).unwrap();
         let attrs_ts = proc_macro2::TokenStream::from_str("").unwrap();
         do_automock(attrs_ts, ts).to_string();
@@ -1451,9 +1451,9 @@ mod automock {
 
     #[test]
     fn trait_visibility() {
-        let code = r#"
+        let code = "
         pub(super) trait Foo {}
-        "#;
+        ";
         let attrs_ts = proc_macro2::TokenStream::from_str("").unwrap();
         let ts = proc_macro2::TokenStream::from_str(code).unwrap();
         let output = do_automock(attrs_ts, ts).to_string();

--- a/mockall_double/src/lib.rs
+++ b/mockall_double/src/lib.rs
@@ -245,19 +245,19 @@ mod double {
     #[test]
     #[should_panic(expected = "Cannot double glob")]
     fn glob() {
-        let code = r#"use foo::*;"#;
+        let code = "use foo::*;";
         cmp("", code, "");
     }
 
     #[test]
     fn group() {
-        let code = r#"
+        let code = "
             use foo::bar::{
                 Baz,
                 Bean
             };
-        "#;
-        let expected = r#"
+        ";
+        let expected = "
             #[cfg(not(test))]
             use foo::bar::{
                 Baz,
@@ -268,81 +268,81 @@ mod double {
                 MockBaz as Baz,
                 MockBean as Bean
             };
-        "#;
+        ";
         cmp("", code, expected);
     }
 
     #[test]
     fn module() {
-        let code = r#"use foo::bar;"#;
-        let expected = r#"
+        let code = "use foo::bar;";
+        let expected = "
             #[cfg(not(test))]
             use foo::bar;
             #[cfg(test)]
             use foo::mock_bar as bar;
-        "#;
+        ";
         cmp("", code, expected);
     }
 
     #[test]
     #[should_panic(expected = "Cannot double types in the current module")]
     fn name() {
-        let code = r#"use Foo;"#;
+        let code = "use Foo;";
         cmp("", code, "");
     }
 
     #[test]
     fn path() {
-        let code = r#"use foo::bar::Baz;"#;
-        let expected = r#"
+        let code = "use foo::bar::Baz;";
+        let expected = "
             #[cfg(not(test))]
             use foo::bar::Baz;
             #[cfg(test)]
             use foo::bar::MockBaz as Baz;
-        "#;
+        ";
         cmp("", code, expected);
     }
 
     #[test]
     fn pub_use() {
-        let code = r#"pub use foo::bar;"#;
-        let expected = r#"
+        let code = "pub use foo::bar;";
+        let expected = "
             #[cfg(not(test))]
             pub use foo::bar;
             #[cfg(test)]
             pub use foo::mock_bar as bar;
-        "#;
+        ";
         cmp("", code, expected);
     }
 
     #[test]
     fn rename() {
-        let code = r#"use Foo as Bar;"#;
-        let expected = r#"
+        let code = "use Foo as Bar;";
+        let expected = "
             #[cfg(not(test))]
             use Foo as Bar;
             #[cfg(test)]
             use MockFoo as Bar;
-        "#;
+        ";
         cmp("", code, expected);
     }
 
     #[test]
     fn type_() {
-        let code = r#"type Foo = bar::Baz;"#;
-        let expected = r#"
+        let code = "type Foo = bar::Baz;";
+        let expected = "
             #[cfg(not(test))]
             type Foo = bar::Baz;
             #[cfg(test)]
             type Foo = bar::MockBaz;
-        "#;
+        ";
         cmp("", code, expected);
     }
 
     #[test]
     #[should_panic(expected = "Only use statements and type aliases")]
     fn undoubleable() {
-        let code = r#"struct Foo{}"#;
+        let code = "struct Foo{}";
         cmp("", code, "");
     }
 }


### PR DESCRIPTION
There were a bunch of raw string literals in the unit tests.  I'm not sure why I used them; probably because of something to do with whitespace.  But they aren't necessary, and Clippy complains.