### PR TITLE
Clarify "namespace" to "name"

### DIFF
--- a/mockall/src/lib.rs
+++ b/mockall/src/lib.rs
@@ -1390,8 +1390,8 @@ pub use mockall_derive::concretize;
 /// ```
 ///
 /// When mocking a generic struct's implementation of a generic trait, use the
-/// same namespace for their generic parameters.  For example, if you wanted to
-/// mock `Rc`, do
+/// same name for their generic parameters.  For example, if you wanted to mock
+/// `Rc`, do
 /// ```
 /// # use mockall_derive::mock;
 /// mock!{


### PR DESCRIPTION
I think _name_ is more appropriate here since _namespace_ normally refers the grouping done by an `impl` blocks and modules.