### PR TITLE
Add a test for the Return Position Impl Trait in Trait feature

### DIFF
--- a/mockall/tests/automock_rpitit.rs
+++ b/mockall/tests/automock_rpitit.rs
@@ -1,0 +1,22 @@
+// vim: tw=80
+//! Return position Impl Trait in Traits
+//! https://rust-lang.github.io/rfcs/3425-return-position-impl-trait-in-traits.html
+#![cfg(feature = "nightly")]
+#![deny(warnings)]
+
+use std::fmt::Debug;
+
+use mockall::*;
+
+#[automock]
+trait Foo {
+    fn bar(&self) -> impl Debug;
+}
+
+#[test]
+fn returning() {
+    let mut foo = MockFoo::default();
+    foo.expect_bar()
+        .returning(|| Box::new(42u32));
+    assert_eq!("42", format!("{:?}", foo.bar()));
+}


### PR DESCRIPTION
In nightly compilers, it's now possible to return `impl Trait` in a trait method.  Mockall needs nothing new to support this.  The existing "deimplify" strategy, already used for inherent methods, works for trait methods too.

The generated code will still return `Box<dyn Trait>` instead of `impl Trait`.  We can't easily change that because the generated code also includes things like `Fn() -> impl Trait`, and Rust does not yet allow "impl Trait" as a return type for closures.  The generated code also includes things like `Into<impl Trait>`, which makes even less sense.

https://rust-lang.github.io/rfcs/3425-return-position-impl-trait-in-traits.html