### PR TITLE
Less Mutex poisoning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Raised MSRV to 1.70.0 to remove `lazy_static` dependency
   ([#550](https://github.com/asomers/mockall/pull/550))
 
+- No longer poison a Context object's internal `Mutex` when panicing.  This
+  requires the "nightly" feature.
+  ([#527](https://github.com/asomers/mockall/pull/527))
+
 ## [ 0.12.1 ] - 2023-12-21
 
 ### Fixed

--- a/mockall/tests/clear_expectations_on_panic.rs
+++ b/mockall/tests/clear_expectations_on_panic.rs
@@ -34,7 +34,7 @@ fn too_few_calls() {
 
 // We shouldn't panic during drop in this case.  Regression test for
 // https://github.com/asomers/mockall/issues/491
-#[should_panic(expected = "called `Result::unwrap()` on an `Err` value: PoisonError { .. }")]
+#[cfg_attr(not(feature = "nightly"), ignore)]
 #[test]
 fn too_many_calls() {
     panic::catch_unwind(|| {


### PR DESCRIPTION
If a test case panics while holding a static method's internal Mutex locked, for example by violating a times() constraint, then clear the Mutex's poison during Drop.  We're going to delete all of its Expectations anyway, so there's no data to be poisoned.

Requires nightly.

Fixes #515