### PR TITLE
Change the recommendation for static methods

### DIFF
--- a/mockall/tests/mock_struct_with_static_method.rs
+++ b/mockall/tests/mock_struct_with_static_method.rs
@@ -7,9 +7,6 @@ use std::sync::Mutex;
 mock!{
     Foo {
         fn bar(x: u32) -> u64;
-        // We must have a separate method for every should_panic test
-        fn bar2(x: u32) -> u64;
-        fn bar3(x: u32) -> u64;
     }
 }
 
@@ -20,7 +17,7 @@ lazy_static! {
 // Checkpointing the mock object should not checkpoint static methods
 #[test]
 fn checkpoint() {
-    let _m = BAR_MTX.lock().unwrap();
+    let _m = BAR_MTX.lock();
 
     let mut mock = MockFoo::new();
     let ctx = MockFoo::bar_context();
@@ -34,9 +31,11 @@ fn checkpoint() {
 // It should also be possible to checkpoint just the context object
 #[test]
 #[should_panic(expected =
-    "MockFoo::bar2: Expectation(<anything>) called 0 time(s) which is fewer than expected 1")]
+    "MockFoo::bar: Expectation(<anything>) called 0 time(s) which is fewer than expected 1")]
 fn ctx_checkpoint() {
-    let ctx = MockFoo::bar2_context();
+    let _m = BAR_MTX.lock();
+
+    let ctx = MockFoo::bar_context();
     ctx.expect()
         .returning(|_| 32)
         .times(1..3);
@@ -46,19 +45,21 @@ fn ctx_checkpoint() {
 
 // Expectations should be cleared when a context object drops
 #[test]
-#[should_panic(expected = "MockFoo::bar3(42): No matching expectation found")]
+#[should_panic(expected = "MockFoo::bar(42): No matching expectation found")]
 fn ctx_hygiene() {
+    let _m = BAR_MTX.lock();
+
     {
-        let ctx0 = MockFoo::bar3_context();
+        let ctx0 = MockFoo::bar_context();
         ctx0.expect()
             .returning(|x| u64::from(x + 1));
     }
-    MockFoo::bar3(42);
+    MockFoo::bar(42);
 }
 
 #[test]
 fn return_const() {
-    let _m = BAR_MTX.lock().unwrap();
+    let _m = BAR_MTX.lock();
 
     let ctx = MockFoo::bar_context();
     ctx.expect()
@@ -70,7 +71,7 @@ fn return_const() {
 #[cfg_attr(not(feature = "nightly"), allow(unused_must_use))]
 #[test]
 fn return_default() {
-    let _m = BAR_MTX.lock().unwrap();
+    let _m = BAR_MTX.lock();
 
     let ctx = MockFoo::bar_context();
     ctx.expect();
@@ -80,7 +81,7 @@ fn return_default() {
 
 #[test]
 fn returning() {
-    let _m = BAR_MTX.lock().unwrap();
+    let _m = BAR_MTX.lock();
 
     let ctx = MockFoo::bar_context();
     ctx.expect()
@@ -90,7 +91,7 @@ fn returning() {
 
 #[test]
 fn two_matches() {
-    let _m = BAR_MTX.lock().unwrap();
+    let _m = BAR_MTX.lock();
 
     let ctx = MockFoo::bar_context();
     ctx.expect()


### PR DESCRIPTION
Using a static method in two or more test cases requires synchronization, such as with a Mutex.  Previously we recommended adding a `let _m = SOME_MTX.lock().unwrap()` to the top of each such test case. But if one test case should fail, then the others will fail too due to a poisoned mutex.  It turns out that the `.unwrap()` is completely unnecessary; a poisoned Mutex still provides the necessary synchronization.  So simply remove all of the unwraps.