### PR TITLE
Fix using #[concretize] on functions with bounded generic types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 
+## [ Unreleased ] - ReleaseDate
+
+### Fixed
+
+- Fixed using `#[mockall::concretize]` on functions whose generic types contain
+  trait bounds, yet are still object safe.
+  ([#531](https://github.com/asomers/mockall/pull/531))
+
 ## [ 0.12.0 ] - 2023-12-10
 
 ### Added

--- a/mockall/tests/mock_concretize_with_bounds.rs
+++ b/mockall/tests/mock_concretize_with_bounds.rs
@@ -1,0 +1,135 @@
+// vim: tw=80
+//! Using #[concretize] on generic types with trait bounds
+#![deny(warnings)]
+
+use mockall::*;
+use std::path::{Path, PathBuf};
+
+trait AsRefMut<T: ?Sized>: AsRef<T> + AsMut<T> {}
+impl<Q, T> AsRefMut<T> for Q where Q: AsRef<T> + AsMut<T>, T: ?Sized {}
+
+mock! {
+    Foo {
+        /// Base concretized function
+        #[mockall::concretize]
+        fn foo<P: AsRef<std::path::Path> + Send>(&self, x: P);
+
+        /// With a where clause
+        #[mockall::concretize]
+        fn boom<P>(&self, x: P) where P: AsRef<std::path::Path> + Send;
+
+        /// Static function
+        #[mockall::concretize]
+        fn bang<P: AsRef<std::path::Path> + Send>(x: P);
+
+        /// Reference argument
+        #[mockall::concretize]
+        fn boomref<P: AsRef<std::path::Path> + Send>(&self, x: &P);
+
+        /// Mutable reference argument
+        #[mockall::concretize]
+        fn boom_mutref<T: AsRefMut<str> + Send>(&self, x: &mut T);
+
+        /// Slice argument
+        #[mockall::concretize]
+        fn boomv<P>(&self, x: &[P]) where P: AsRef<std::path::Path> + Send;
+    }
+}
+
+mod generic_arg {
+    use super::*;
+
+    #[test]
+    fn withf() {
+        let mut foo = MockFoo::new();
+        foo.expect_foo()
+            .withf(|p| p.as_ref() == Path::new("/tmp"))
+            .times(3)
+            .return_const(());
+        foo.foo(Path::new("/tmp"));
+        foo.foo(PathBuf::from(Path::new("/tmp")));
+        foo.foo("/tmp");
+    }
+}
+
+mod where_clause {
+    use super::*;
+
+    #[test]
+    fn withf() {
+        let mut foo = MockFoo::new();
+        foo.expect_boom()
+            .withf(|p| p.as_ref() == Path::new("/tmp"))
+            .times(3)
+            .return_const(());
+        foo.boom(Path::new("/tmp"));
+        foo.boom(PathBuf::from(Path::new("/tmp")));
+        foo.boom("/tmp");
+    }
+}
+
+mod mutable_reference_arg {
+    use super::*;
+
+    #[test]
+    fn withf() {
+        let mut foo = MockFoo::new();
+        foo.expect_boom_mutref()
+            .withf(|p| p.as_ref() == "/tmp")
+            .once()
+            .returning(|s| s.as_mut().make_ascii_uppercase());
+        let mut s = String::from("/tmp");
+        foo.boom_mutref(&mut s);
+        assert_eq!(s, "/TMP");
+    }
+}
+
+mod reference_arg {
+    use super::*;
+
+    #[test]
+    fn withf() {
+        let mut foo = MockFoo::new();
+        foo.expect_boomref()
+            .withf(|p| p.as_ref() == Path::new("/tmp"))
+            .times(3)
+            .return_const(());
+        foo.boomref(&Path::new("/tmp"));
+        foo.boomref(&PathBuf::from(Path::new("/tmp")));
+        foo.boomref(&"/tmp");
+    }
+}
+
+mod slice {
+    use super::*;
+
+    #[test]
+    fn withf() {
+        let mut foo = MockFoo::new();
+        foo.expect_boomv()
+            .withf(|v|
+                   v[0].as_ref() == Path::new("/tmp") &&
+                   v[1].as_ref() == Path::new("/mnt")
+            ).times(3)
+            .return_const(());
+        foo.boomv(&[Path::new("/tmp"), Path::new("/mnt")]);
+        foo.boomv(&[PathBuf::from("/tmp"), PathBuf::from("/mnt")]);
+        foo.boomv(&["/tmp", "/mnt"]);
+    }
+}
+
+mod static_method {
+    use super::*;
+
+    #[test]
+    fn withf() {
+        let ctx = MockFoo::bang_context();
+        ctx.expect()
+            .withf(|p| p.as_ref() == Path::new("/tmp"))
+            .times(3)
+            .return_const(());
+        MockFoo::bang(Path::new("/tmp"));
+        MockFoo::bang(PathBuf::from(Path::new("/tmp")));
+        MockFoo::bang("/tmp");
+    }
+}


### PR DESCRIPTION
It's usually possible to turn such types into trait objects.  We just need to emit extra parenthesis in the generated code.

Fixes #530