### PR TITLE
Fix mocking functions that use raw identifiers for their names.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   trait bounds, yet are still object safe.
   ([#531](https://github.com/asomers/mockall/pull/531))
 
+- Fixed mocking methods that use raw identifiers for their names.  This was a
+  regression in 0.12.0.
+  ([#534](https://github.com/asomers/mockall/pull/534))
+
 ## [ 0.12.0 ] - 2023-12-10
 
 ### Added

--- a/mockall/tests/raw_identifier.rs
+++ b/mockall/tests/raw_identifier.rs
@@ -1,0 +1,72 @@
+// vim: tw=80
+//! It should be possible to mock things that use raw identifiers
+#![deny(warnings)]
+#![allow(non_camel_case_types)]
+
+use mockall::*;
+
+#[automock]
+trait r#while {
+    fn r#match(&self);
+    fn r#loop();
+}
+
+#[automock]
+pub mod r#break {
+    pub fn r#if() {unimplemented!() }
+}
+
+mock! {
+    r#do {}
+    impl r#while for r#do {
+        fn r#match(&self);
+        fn r#loop();
+    }
+}
+
+struct r#else {}
+#[automock]
+impl r#while for r#else {
+    fn r#match(&self) {unimplemented!()}
+    fn r#loop() {unimplemented!()}
+}
+
+#[test]
+fn by_ref() {
+    let mut foo = Mockwhile::new();
+    foo.expect_match()
+        .return_const(());
+    foo.r#match();
+}
+
+#[test]
+fn static_method() {
+    let ctx = Mockwhile::loop_context();
+    ctx.expect()
+        .returning(|| ());
+    Mockwhile::r#loop();
+}
+
+#[test]
+fn manual_mock() {
+    let mut foo = Mockdo::new();
+    foo.expect_match()
+        .return_const(());
+    foo.r#match();
+}
+
+#[test]
+fn module() {
+    let ctx = mock_break::if_context();
+    ctx.expect()
+        .returning(|| ());
+    mock_break::r#if();
+}
+
+#[test]
+fn trait_impl() {
+    let mut mock = Mockelse::new();
+    mock.expect_match()
+        .returning(|| ());
+    mock.r#match();
+}

--- a/mockall_derive/src/lib.rs
+++ b/mockall_derive/src/lib.rs
@@ -970,14 +970,14 @@ fn gen_keyid(g: &Generics) -> impl ToTokens {
 
 /// Generate a mock identifier from the regular one: eg "Foo" => "MockFoo"
 fn gen_mock_ident(ident: &Ident) -> Ident {
-    format_ident!("Mock{ident}")
+    format_ident!("Mock{}", ident)
 }
 
 /// Generate an identifier for the mock struct's private module: eg "Foo" =>
 /// "__mock_Foo"
 fn gen_mod_ident(struct_: &Ident, trait_: Option<&Ident>) -> Ident {
     if let Some(t) = trait_ {
-        format_ident!("__mock_{struct_}_{t}")
+        format_ident!("__mock_{struct_}_{}", t)
     } else {
         format_ident!("__mock_{struct_}")
     }

--- a/mockall_derive/src/mock_function.rs
+++ b/mockall_derive/src/mock_function.rs
@@ -629,7 +629,7 @@ impl MockFunction {
             .doc(false)
             .format();
         let name = self.name();
-        let expect_ident = format_ident!("expect_{name}");
+        let expect_ident = format_ident!("expect_{}", name);
         let expectation_obj = self.expectation_obj(self_args);
         let funcname = &self.sig.ident;
         let (_, tg, _) = if self.is_method_generic() {


### PR DESCRIPTION
This was a regression in 0.12.0, introduced by 60acf8e .

Fixes #533