### PR TITLE
[skip ci] Clarify license terms

### DIFF
--- a/mockall/Cargo.toml
+++ b/mockall/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mockall"
 version = "0.12.0"
 authors = ["Alan Somers <asomers@gmail.com>"]
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/asomers/mockall"
 categories = ["development-tools::testing"]

--- a/mockall_derive/Cargo.toml
+++ b/mockall_derive/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mockall_derive"
 version = "0.12.0"
 authors = ["Alan Somers <asomers@gmail.com>"]
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 repository = "https://github.com/asomers/mockall"
 categories = ["development-tools::testing"]
 keywords = ["mock", "mocking", "testing"]

--- a/mockall_double/Cargo.toml
+++ b/mockall_double/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mockall_double"
 version = "0.3.1"
 authors = ["Alan Somers <asomers@gmail.com>"]
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 repository = "https://github.com/asomers/mockall"
 categories = ["development-tools::testing"]
 keywords = ["mock", "mocking", "testing"]


### PR DESCRIPTION
Clarify that Mockall may be distributed under the terms of either the MIT or Apache-2.0 license.  This was always the intent, but was never expressed using the recommended SPDX syntax.

Fixes #529