### PR TITLE
Document generic parameters' lifetime requirements more precisely.

### DIFF
--- a/mockall/src/lib.rs
+++ b/mockall/src/lib.rs
@@ -740,14 +740,14 @@
 //! ## Generic traits and structs
 //!
 //! Mocking generic structs and generic traits is not a problem.  The mock
-//! struct will be generic, too.  The same restrictions apply as with mocking
-//! generic methods: each generic parameter must be `'static`, and generic
-//! lifetime parameters are not allowed.
+//! struct will be generic, too.  As with generic methods, lifetime parameters
+//! are not allowed.  However, as long as the generic parameters are not used by
+//! any static methods, then the parameters need not be `'static'`.
 //!
 //! ```
 //! # use mockall::*;
 //! #[automock]
-//! trait Foo<T: 'static> {
+//! trait Foo<T> {
 //!     fn foo(&self, t: T) -> i32;
 //! }
 //!
@@ -899,7 +899,8 @@
 //! ### Generic static methods
 //!
 //! Mocking static methods of generic structs or traits, whether or not the
-//! methods themselves are generic, should work seamlessly.
+//! methods themselves are generic, should work seamlessly as long as the
+//! generic parameter is `'static`
 //!
 //! ```
 //! # use mockall::*;
@@ -1395,8 +1396,8 @@ pub use mockall_derive::concretize;
 /// ```
 /// # use mockall_derive::mock;
 /// mock!{
-///     pub Rc<T: 'static> {}
-///     impl<T: 'static> AsRef<T> for Rc<T> {
+///     pub Rc<T> {}
+///     impl<T> AsRef<T> for Rc<T> {
 ///         fn as_ref(&self) -> &T;
 ///     }
 /// }
@@ -1406,8 +1407,8 @@ pub use mockall_derive::concretize;
 /// ```compile_fail
 /// # use mockall_derive::mock;
 /// mock!{
-///     pub Rc<Q: 'static> {}
-///     impl<T: 'static> AsRef<T> for Rc<T> {
+///     pub Rc<Q> {}
+///     impl<T> AsRef<T> for Rc<T> {
 ///         fn as_ref(&self) -> &T;
 ///     }
 /// }

--- a/mockall/tests/automock_generic_future.rs
+++ b/mockall/tests/automock_generic_future.rs
@@ -13,10 +13,10 @@ use std::{
     task::{Context, Poll},
 };
 
-struct Foo<T: 'static>(T);
+struct Foo<T>(T);
 
 #[automock]
-impl<T: 'static> Future for Foo<T> {
+impl<T> Future for Foo<T> {
     type Output = ();
 
     fn poll<'a>(self: Pin<&mut Self>, _cx: &mut Context<'a>)

--- a/mockall/tests/automock_generic_future_with_where_clause.rs
+++ b/mockall/tests/automock_generic_future_with_where_clause.rs
@@ -9,7 +9,7 @@
 
 use mockall::*;
 
-struct Foo<T: 'static, V: 'static>((T, V));
+struct Foo<T, V>((T, V));
 trait MyTrait {
     type Item;
 
@@ -18,7 +18,7 @@ trait MyTrait {
 pub struct NonStatic<'ns>(&'ns i32);
 
 #[automock]
-impl<T: 'static, V: 'static> MyTrait for Foo<T, V> where T: Clone {
+impl<T, V> MyTrait for Foo<T, V> where T: Clone {
     type Item = V;
 
     fn myfunc<'a>(&self, _cx: &NonStatic<'a>) -> V { unimplemented!() }

--- a/mockall/tests/automock_generic_struct.rs
+++ b/mockall/tests/automock_generic_struct.rs
@@ -9,7 +9,7 @@ pub struct GenericStruct<T, V> {
     _v: V
 }
 #[automock]
-impl<T: 'static, V: 'static> GenericStruct<T, V> {
+impl<T, V> GenericStruct<T, V> {
     pub fn foo(&self, _x: u32) -> i64 {
         42
     }

--- a/mockall/tests/automock_generic_struct_with_bounds.rs
+++ b/mockall/tests/automock_generic_struct_with_bounds.rs
@@ -9,7 +9,7 @@ pub struct GenericStruct<T: Copy, V: Clone> {
     _v: V
 }
 #[automock]
-impl<T: Copy + 'static, V: Clone + 'static> GenericStruct<T, V> {
+impl<T: Copy + Copy, V: Clone + Copy> GenericStruct<T, V> {
     pub fn foo(&self, _x: u32) -> i64 {
         42
     }

--- a/mockall/tests/automock_generic_struct_with_where_clause.rs
+++ b/mockall/tests/automock_generic_struct_with_where_clause.rs
@@ -4,12 +4,12 @@
 
 use mockall::*;
 
-pub struct GenericStruct<T: 'static> {
+pub struct GenericStruct<T> {
     _t: T,
 }
 #[automock]
 impl<T> GenericStruct<T>
-    where T: Clone + Default + 'static
+    where T: Clone + Default
 {
     #[allow(clippy::redundant_clone)]
     pub fn foo(&self, x: T) -> T {

--- a/mockall/tests/automock_generic_trait.rs
+++ b/mockall/tests/automock_generic_trait.rs
@@ -5,14 +5,26 @@
 use mockall::*;
 
 #[automock]
-trait A<T: 'static> {
-    fn foo(&self);
+trait A<T> {
+    fn foo(&self, t: T);
+    fn bar(&self) -> T;
 }
 
 #[test]
-fn returning() {
+fn generic_arguments() {
     let mut mock = MockA::<u32>::new();
     mock.expect_foo()
-        .returning(|| ());
-    mock.foo();
+        .with(mockall::predicate::eq(16u32))
+        .once()
+        .returning(|_| ());
+    mock.foo(16u32);
 }
+
+#[test]
+fn generic_return() {
+    let mut mock = MockA::<u32>::new();
+    mock.expect_bar()
+        .returning(|| 42u32);
+    assert_eq!(42u32, mock.bar());
+}
+

--- a/mockall/tests/automock_generic_trait_with_bounds.rs
+++ b/mockall/tests/automock_generic_trait_with_bounds.rs
@@ -5,7 +5,7 @@
 use mockall::*;
 
 #[automock]
-trait A<T: Copy + 'static> {
+trait A<T: Copy> {
     fn foo(&self);
 }
 

--- a/mockall/tests/automock_generic_trait_with_where_clause.rs
+++ b/mockall/tests/automock_generic_trait_with_where_clause.rs
@@ -5,7 +5,7 @@
 use mockall::*;
 
 #[automock]
-trait Foo<T> where T: Clone + 'static {
+trait Foo<T> where T: Clone + Copy {
     fn foo(&self);
 }
 

--- a/mockall/tests/automock_impl_generic_trait_for.rs
+++ b/mockall/tests/automock_impl_generic_trait_for.rs
@@ -4,16 +4,16 @@
 
 use mockall::*;
 
-trait Foo<T: 'static> {
+trait Foo<T> {
     fn foo(&self, t: T) -> T;
 }
 
-pub struct SomeStruct<T: 'static> {
+pub struct SomeStruct<T> {
     _t: std::marker::PhantomData<T>
 }
 
 #[automock]
-impl<T: 'static> Foo<T> for SomeStruct<T> {
+impl<T> Foo<T> for SomeStruct<T> {
     fn foo(&self, t: T) -> T {
         t
     }

--- a/mockall/tests/automock_impl_trait_for_generic.rs
+++ b/mockall/tests/automock_impl_trait_for_generic.rs
@@ -8,12 +8,12 @@ trait Foo {
     fn foo(&self, x: u32) -> i64;
 }
 
-pub struct SomeStruct<T: 'static> {
+pub struct SomeStruct<T> {
     _t: std::marker::PhantomData<T>
 }
 
 #[automock]
-impl<T: 'static> Foo for SomeStruct<T> {
+impl<T> Foo for SomeStruct<T> {
     fn foo(&self, _x: u32) -> i64 {
         42
     }

--- a/mockall/tests/automock_specializing_methods.rs
+++ b/mockall/tests/automock_specializing_methods.rs
@@ -6,14 +6,14 @@
 
 use mockall::*;
 
-struct G<T: Copy + Default + 'static>(T);
+struct G<T: Copy + Default>(T);
 
 #[derive(Clone, Copy)]
 struct NonDefault(u32);
 
 #[automock]
-trait Foo<T> where T: Copy + 'static {
-    fn foo(&self, t: T) -> G<T> where T: Default;
+trait Foo<T> where T: Copy {
+    fn foo(&self, t: T) -> G<T> where T: Default + 'static;
 }
 
 #[test]

--- a/mockall/tests/mock_concrete_struct_with_generic_trait.rs
+++ b/mockall/tests/mock_concrete_struct_with_generic_trait.rs
@@ -4,7 +4,7 @@
 
 use mockall::*;
 
-trait Foo<T: 'static> {
+trait Foo<T> {
     fn foo(&self, x: T) -> T;
 }
 mock! {

--- a/mockall/tests/mock_generic_constructor.rs
+++ b/mockall/tests/mock_generic_constructor.rs
@@ -6,7 +6,7 @@
 use mockall::*;
 
 mock! {
-    pub Foo<T: Default +'static> {
+    pub Foo<T: Default + 'static> {
         fn build() -> MockFoo<T>;
     }
 }

--- a/mockall/tests/mock_generic_method_on_generic_struct_returning_nonstatic.rs
+++ b/mockall/tests/mock_generic_method_on_generic_struct_returning_nonstatic.rs
@@ -15,7 +15,7 @@ trait Bong {
 }
 
 mock! {
-    Thing<T: 'static> {
+    Thing<T> {
         fn foo<'a>(&self) -> X<'a>;
 
         // XXX static methods don't work yet.
@@ -34,7 +34,7 @@ mock! {
         //fn bean<'a, T: 'static>(&self, t: T) -> X<'a>;
     }
     // The same types of methods should work if they are Trait methods.
-    impl<T: 'static> Bong for Thing<T> {
+    impl<T> Bong for Thing<T> {
         fn trait_foo<'a>(&self) -> X<'a>;
         fn trait_baz<'a>(&self) -> &X<'a>;
     }

--- a/mockall/tests/mock_generic_struct.rs
+++ b/mockall/tests/mock_generic_struct.rs
@@ -17,7 +17,7 @@ struct NonCopy(u32);
 // }
 // Could be mocked like this:
 mock!{
-    pub ExtGenericStruct<T: Clone + 'static> {
+    pub ExtGenericStruct<T: Clone> {
         fn foo(&self, x: T) -> T;
     }
 }

--- a/mockall/tests/mock_generic_struct_with_bounds.rs
+++ b/mockall/tests/mock_generic_struct_with_bounds.rs
@@ -4,7 +4,7 @@
 use mockall::*;
 
 mock! {
-    pub Foo<T: Clone + 'static> {
+    pub Foo<T: Clone + Copy> {
         fn foo(&self, x: u32) -> i64;
     }
 }

--- a/mockall/tests/mock_generic_struct_with_generic_trait.rs
+++ b/mockall/tests/mock_generic_struct_with_generic_trait.rs
@@ -3,12 +3,12 @@
 
 use mockall::*;
 
-trait Foo<T: 'static> {
+trait Foo<T> {
     fn foo(&self, x: T) -> T;
 }
 mock! {
-    Bar<T: 'static, Z: 'static> {}
-    impl<T: 'static, Z: 'static> Foo<T> for Bar<T, Z> {
+    Bar<T, Z> {}
+    impl<T, Z> Foo<T> for Bar<T, Z> {
         fn foo(&self, x: T) -> T;
     }
 }

--- a/mockall/tests/mock_generic_struct_with_generic_trait_with_different_bounds.rs
+++ b/mockall/tests/mock_generic_struct_with_generic_trait_with_different_bounds.rs
@@ -7,8 +7,8 @@ trait Foo<T> {
     fn foo(&self, x: T) -> T;
 }
 mock! {
-    Bar<T: 'static> {}
-    impl<T: 'static> Foo<T> for Bar<T> {
+    Bar<T> {}
+    impl<T: Copy> Foo<T> for Bar<T> {
         fn foo(&self, x: T) -> T;
     }
 }

--- a/mockall/tests/mock_generic_struct_with_nondefault_parameter.rs
+++ b/mockall/tests/mock_generic_struct_with_nondefault_parameter.rs
@@ -7,12 +7,12 @@ use mockall::*;
 
 struct NonDefault();
 
-trait Foo<T: 'static> {
+trait Foo<T> {
     fn foo(&self) -> T;
 }
 mock! {
-    ExternalStruct<T: 'static> {}
-    impl<T: 'static> Foo<T> for ExternalStruct<T> {
+    ExternalStruct<T> {}
+    impl<T> Foo<T> for ExternalStruct<T> {
         fn foo(&self) -> T;
     }
 }

--- a/mockall/tests/mock_generic_struct_with_trait.rs
+++ b/mockall/tests/mock_generic_struct_with_trait.rs
@@ -8,8 +8,8 @@ trait Foo {
 }
 
 mock! {
-    Bar<T: Copy + 'static> {}
-    impl<T: Copy + 'static> Foo for Bar<T> {
+    Bar<T: Copy> {}
+    impl<T: Copy> Foo for Bar<T> {
         fn foo(&self, x: u32) -> u32;
     }
 }

--- a/mockall/tests/mock_generic_struct_with_trait_with_associated_types.rs
+++ b/mockall/tests/mock_generic_struct_with_trait_with_associated_types.rs
@@ -4,8 +4,8 @@
 use mockall::*;
 
 mock! {
-    Foo<T: 'static> {}
-    impl<T: 'static> Iterator for Foo<T> {
+    Foo<T> {}
+    impl<T> Iterator for Foo<T> {
         type Item=T;
         fn next(&mut self) -> Option<T>;
     }

--- a/mockall/tests/mock_generic_struct_with_where_clause.rs
+++ b/mockall/tests/mock_generic_struct_with_where_clause.rs
@@ -8,7 +8,7 @@
 use mockall::*;
 
 mock! {
-    Foo<T: 'static> where T:Clone {
+    Foo<T> where T:Clone {
         fn foo(&self, t: T) -> T;
     }
 }

--- a/mockall/tests/mock_generic_struct_with_where_clause_and_trait.rs
+++ b/mockall/tests/mock_generic_struct_with_where_clause_and_trait.rs
@@ -11,10 +11,10 @@ trait Bar {
     fn bar(&self);
 }
 mock! {
-    Foo<T: 'static> where T: Clone {
+    Foo<T> where T: Clone {
         fn foo(&self, t: T) -> T;
     }
-    impl<T: 'static> Bar for Foo<T> where T: Clone {
+    impl<T> Bar for Foo<T> where T: Clone {
         fn bar(&self);
     }
 }

--- a/mockall/tests/mock_generic_trait.rs
+++ b/mockall/tests/mock_generic_trait.rs
@@ -8,8 +8,8 @@ trait Foo {
 }
 
 mock! {
-    Bar<T: 'static> {}
-    impl<T: 'static> Foo for Bar<T> {
+    Bar<T> {}
+    impl<T> Foo for Bar<T> {
         fn foo(&self);
     }
 }

--- a/mockall/tests/mock_same_trait_twice_on_generic_struct.rs
+++ b/mockall/tests/mock_same_trait_twice_on_generic_struct.rs
@@ -8,7 +8,7 @@
 use mockall::*;
 
 mock! {
-    pub Foo<T: 'static> {}
+    pub Foo<T> {}
     impl Into<u32> for Foo<u32> {
         fn into(self) -> u32;
     }

--- a/mockall/tests/mock_specializing_methods.rs
+++ b/mockall/tests/mock_specializing_methods.rs
@@ -6,14 +6,14 @@
 
 use mockall::*;
 
-struct G<T: Copy + Default + 'static>(T);
+struct G<T: Copy + Default>(T);
 
 #[derive(Clone, Copy)]
 struct NonDefault(u32);
 
 mock!{
-    Foo<T> where T: Copy + 'static {
-        fn foo(&self, t: T) -> G<T> where T: Default;
+    Foo<T> where T: Copy {
+        fn foo(&self, t: T) -> G<T> where T: Default + 'static;
     }
 }
 


### PR DESCRIPTION
Mockall actually _can_ mock generic structs and traits with non-'static generic parameters.  The only thing it can't do is:
* generic methods with non-'static generic parameters
* generic structs and traits that have non-'static generic parameters and also have static methods.

I'm not sure at what point Mockall gained this ability.  Probably one of the several internal refactorings.