### PR TITLE
Clippy cleanup

### DIFF
--- a/mockall/tests/anyhow.rs
+++ b/mockall/tests/anyhow.rs
@@ -18,7 +18,7 @@ pub fn Ok<T>(t: T) -> Result<T> {
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
 #[automock]
-trait Foo {
+pub trait Foo {
     fn foo(&self) -> Result<(), Error>;
     fn reffoo(&self) -> &Result<(), Error>;
     fn refmutfoo(&mut self) -> &mut Result<(), Error>;

--- a/mockall/tests/automock_extern_std.rs
+++ b/mockall/tests/automock_extern_std.rs
@@ -9,7 +9,7 @@ extern crate std;
 use mockall::*;
 
 #[automock]
-trait SimpleTrait {
+pub trait SimpleTrait {
     fn foo(&self, x: u32) -> u32;
 }
 

--- a/mockall/tests/automock_multiple_lifetime_parameters.rs
+++ b/mockall/tests/automock_multiple_lifetime_parameters.rs
@@ -10,6 +10,6 @@
 use mockall::*;
 
 #[automock]
-trait Foo {
+pub trait Foo {
     fn foo<'a, 'b, 'c, 'd, 'e, 'f>(&self, x: &'a &'b &'c &'d &'e &'f i32);
 }

--- a/mockall/tests/automock_send.rs
+++ b/mockall/tests/automock_send.rs
@@ -5,7 +5,7 @@
 use mockall::*;
 
 #[automock]
-trait T {
+pub trait T {
     fn foo(&self) -> u32;
 }
 

--- a/mockall/tests/mock_cfg.rs
+++ b/mockall/tests/mock_cfg.rs
@@ -7,11 +7,11 @@ use mockall::*;
 // For this test, use the "nightly" feature as the cfg gate, because it's tested
 // both ways in CI.
 #[cfg(feature = "nightly")]
-trait Beez {
+pub trait Beez {
     fn beez(&self);
 }
 #[cfg(not(feature = "nightly"))]
-trait Beez {
+pub trait Beez {
     fn beez(&self, x: i32) -> i32;
 }
 

--- a/mockall/tests/mock_docs.rs
+++ b/mockall/tests/mock_docs.rs
@@ -8,7 +8,7 @@ use mockall::*;
 // ensures that the code will compile.  mockall_derive has a unit test to ensure
 // that the doc comments are correctly placed.
 
-trait Tr {
+pub trait Tr {
     fn bar(&self);
 }
 

--- a/mockall_derive/src/mock_function.rs
+++ b/mockall_derive/src/mock_function.rs
@@ -1,7 +1,31 @@
 // vim: tw=80
-use super::*;
+use proc_macro2::{Span, TokenStream};
+use quote::{ToTokens, format_ident, quote};
+use syn::{
+    *,
+    punctuated::Punctuated,
+    spanned::Spanned
+};
 
-use quote::ToTokens;
+
+use crate::{
+    AttrFormatter,
+    HashSet,
+    compile_error,
+    concretize_args,
+    declosurefy,
+    expectation_visibility,
+    gen_keyid,
+    is_concretize,
+    lifetimes_to_generic_params,
+    lifetimes_to_generics,
+    merge_generics,
+    pat_is_self,
+    split_lifetimes,
+    staticize,
+    supersuperfy,
+    supersuperfy_generics,
+};
 
 /// Convert a trait object reference into a reference to a Boxed trait
 ///

--- a/mockall_derive/src/mock_item.rs
+++ b/mockall_derive/src/mock_item.rs
@@ -1,8 +1,15 @@
 // vim: tw=80
-use super::*;
+use proc_macro2::{TokenStream};
+use quote::{ToTokens, quote};
+use syn::{
+    *,
+    spanned::Spanned
+};
 
 use crate::{
-    mock_function::MockFunction,
+    MockItemStruct,
+    compile_error,
+    mock_function::{self, MockFunction},
     mockable_item::{MockableItem, MockableModule}
 };
 

--- a/mockall_derive/src/mock_item_struct.rs
+++ b/mockall_derive/src/mock_item_struct.rs
@@ -1,11 +1,19 @@
 // vim: tw=80
-use super::*;
-
-use quote::ToTokens;
 use std::collections::HashSet;
 
+use proc_macro2::TokenStream;
+use quote::{ToTokens, format_ident, quote};
+use syn::{
+    *,
+    spanned::Spanned
+};
+
 use crate::{
-    mock_function::MockFunction,
+    AttrFormatter,
+    MockableStruct,
+    compile_error,
+    gen_mod_ident,
+    mock_function::{self, MockFunction},
     mock_trait::MockTrait
 };
 


### PR DESCRIPTION
The latest nightly compiler complains about unused_imports in mockall_derive and also some dead_code lints in the tests.