### PR TITLE
Fix sequences doc test

### DIFF
--- a/mockall/src/lib.rs
+++ b/mockall/src/lib.rs
@@ -305,7 +305,7 @@
 //! specify the order by using a [`Sequence`].  Any expectations may be added to
 //! the same sequence.  They don't even need to come from the same object.
 //!
-//! ```should_panic(expected = "Method sequence violation")
+//! ```should_panic
 //! # use mockall::*;
 //! #[automock]
 //! trait Foo {


### PR DESCRIPTION
`should_panic` doesn't accept an `expected` parameter for doc tests
(unlike unit tests).

Without this commit cargo doesn't recognise/render it as a doc test.