### PR TITLE
Fix unexpected_cfgs lints with the latest rustc

### DIFF
--- a/mockall/tests/automock_attrs.rs
+++ b/mockall/tests/automock_attrs.rs
@@ -1,6 +1,7 @@
 // vim: tw=80
 //! Attributes are applied to the mock object, too.
 #![deny(warnings)]
+#![allow(unexpected_cfgs)] // multics is deliberately always false
 
 use mockall::*;
 

--- a/mockall/tests/cfg_attr_concretize.rs
+++ b/mockall/tests/cfg_attr_concretize.rs
@@ -1,6 +1,7 @@
 // vim: tw=80
 //! #[concretize] can be used inside of #[cfg_attr()]`
 #![deny(warnings)]
+#![allow(unexpected_cfgs)] // multics is deliberately always false
 
 use std::path::{Path, PathBuf};
 
@@ -8,7 +9,7 @@ use mockall::{automock, concretize};
 
 #[automock]
 trait Foo {
-    #[cfg_attr(not(target_os = "ia64-unknown-multics"), concretize)]
+    #[cfg_attr(not(target_os = "multics"), concretize)]
     fn foo<P: AsRef<Path>>(&self, p: P);
 }
 

--- a/mockall/tests/mock_refmut_arguments.rs
+++ b/mockall/tests/mock_refmut_arguments.rs
@@ -47,6 +47,6 @@ fn static_mut() {
         .withf(|x| *x == 5)
         .returning(|x| { *x = 42;} );
     // Safe because mock leaves scope before x
-    unsafe { mock.bar(mem::transmute::<&mut u32, &mut u32>(&mut x)); }
+    unsafe { mock.bar(mem::transmute::<&mut u32, &'static mut u32>(&mut x)); }
     assert_eq!(x, 42);
 }

--- a/mockall_derive/build.rs
+++ b/mockall_derive/build.rs
@@ -1,0 +1,7 @@
+fn main() {
+    // Avoid unnecessary re-building.
+    println!("cargo:rerun-if-changed=build.rs");
+
+    // Quiet rustc's helpful lint.  reprocheck is defined in CI.
+    println!("cargo::rustc-check-cfg=cfg(reprocheck)");
+}


### PR DESCRIPTION
The latest rustc attempts to detect invalid `#[cfg()]` values.  But some of Mockall's tests conditionalize code on `target_os = "multics"` as an intentionally always-false condition.  Suppress the lint for those files.