### PR TITLE
fix(mockall_derive): add allow(clippy::indexing_slicing) to generated module.

### DIFF
--- a/mockall_derive/src/mock_function.rs
+++ b/mockall_derive/src/mock_function.rs
@@ -860,7 +860,7 @@ impl MockFunction {
         quote!(
             #(#attrs)*
             #[allow(missing_docs)]
-            #[allow(clippy::too_many_arguments)]
+            #[allow(clippy::too_many_arguments, clippy::indexing_slicing)]
             pub mod #inner_mod_ident {
                 use super::*;
                 use ::mockall::CaseTreeExt;


### PR DESCRIPTION
I tend to configure `Cargo.toml` with:

```toml
[workspace.lints.clippy]
indexing_slicing = "deny"
```

[https://rust-lang.github.io/rust-clippy/master/index.html#/indexing_slicing](https://rust-lang.github.io/rust-clippy/master/index.html#/indexing_slicing)

Among other lints to catch code that might panic. The generated code from `mockall` currently fails this lint, and it's difficult to add an exception for it with `#[allow()]` as it's occurring within a proc macro.

This PR updates codegen to replace the instance of index slicing with `.get().unwrap()`. This does not represent any real change in functionality, just passes the lint check now. It will still panic the same as it would have previously.

I am happy to change this to add a `#[allow()]` annotation in the generated code if this is preferred. :)