### PR TITLE
Fix some dead_code warnings in the tests with latest nightly compiler

### DIFF
--- a/mockall/tests/automock_generic_struct.rs
+++ b/mockall/tests/automock_generic_struct.rs
@@ -5,8 +5,8 @@
 use mockall::*;
 
 pub struct GenericStruct<T, V> {
-    _t: T,
-    _v: V
+    pub t: T,
+    pub v: V
 }
 #[automock]
 impl<T, V> GenericStruct<T, V> {

--- a/mockall/tests/automock_generic_struct_with_bounds.rs
+++ b/mockall/tests/automock_generic_struct_with_bounds.rs
@@ -5,8 +5,8 @@
 use mockall::*;
 
 pub struct GenericStruct<T: Copy, V: Clone> {
-    _t: T,
-    _v: V
+    pub t: T,
+    pub v: V
 }
 #[automock]
 impl<T: Copy + Copy, V: Clone + Copy> GenericStruct<T, V> {

--- a/mockall/tests/automock_generic_struct_with_where_clause.rs
+++ b/mockall/tests/automock_generic_struct_with_where_clause.rs
@@ -5,7 +5,7 @@
 use mockall::*;
 
 pub struct GenericStruct<T> {
-    _t: T,
+    pub t: T,
 }
 #[automock]
 impl<T> GenericStruct<T>


### PR DESCRIPTION
These structs are never constructed, and the latest nightly no longer considers a trait impl as enough to keep the struct "live".

https://github.com/rust-lang/rust/pull/125572