### PR TITLE
Use the C-unwind ABI instead of C when mocking extern C functions

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -14,7 +14,7 @@ common: &COMMON
 task:
   name: MSRV
   container:
-    image: rust:1.70.0
+    image: rust:1.71.0
   cargo_lock_script:
     - cp Cargo.lock.msrv Cargo.lock
   << : *COMMON

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,12 +13,18 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
-- Raised MSRV to 1.70.0 to remove `lazy_static` dependency
-  ([#550](https://github.com/asomers/mockall/pull/550))
+- Raised MSRV to 1.71.0 due to the `C-unwind` ABI.
+  ([#585](https://github.com/asomers/mockall/pull/585))
 
 - No longer poison a Context object's internal `Mutex` when panicing.  This
   requires the "nightly" feature.
   ([#527](https://github.com/asomers/mockall/pull/527))
+
+### Fixed
+
+- Fixed panicing within mocked `extern "C"` functions, for example due to
+  unsatisfied expectations, with Rust 1.81.0 or newer.
+  ([#585](https://github.com/asomers/mockall/pull/585))
 
 ## [ 0.12.1 ] - 2023-12-21
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ See the [API docs](https://docs.rs/mockall) for more information.
 
 # Minimum Supported Rust Version (MSRV)
 
-Mockall is supported on Rust 1.70.0 and higher.  Mockall's MSRV will not be
+Mockall is supported on Rust 1.71.0 and higher.  Mockall's MSRV will not be
 changed in the future without bumping the major or minor version.
 
 # License

--- a/mockall/Cargo.toml
+++ b/mockall/Cargo.toml
@@ -9,7 +9,7 @@ categories = ["development-tools::testing"]
 keywords = ["mock", "mocking", "testing"]
 documentation = "https://docs.rs/mockall"
 edition = "2021"
-rust-version = "1.70"
+rust-version = "1.71"
 description = """
 A powerful mock object library for Rust.
 """

--- a/mockall/tests/automock_foreign_c.rs
+++ b/mockall/tests/automock_foreign_c.rs
@@ -47,6 +47,6 @@ fn c_abi() {
     let _m = FOO_MTX.lock();
     let ctx = mock_ffi::foo_context();
     ctx.expect().returning(i64::from);
-    let p: unsafe extern "C" fn(u32) -> i64 = mock_ffi::foo;
+    let p: unsafe extern "C-unwind" fn(u32) -> i64 = mock_ffi::foo;
     assert_eq!(42, unsafe{p(42)});
 }

--- a/mockall/tests/automock_foreign_c_variadic.rs
+++ b/mockall/tests/automock_foreign_c_variadic.rs
@@ -13,11 +13,24 @@ pub mod ffi {
     }
 }
 
+#[cfg(feature = "nightly")]
+static FOO_MTX: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
 #[test]
 #[cfg(feature = "nightly")]
 #[cfg_attr(miri, ignore)]
 fn mocked_c_variadic() {
+    let _m = FOO_MTX.lock();
     let ctx = mock_ffi::foo_context();
     ctx.expect().returning(|x, y| x * y);
     assert_eq!(6, unsafe{mock_ffi::foo(2, 3, 1, 4, 1)});
+}
+
+#[test]
+#[cfg(feature = "nightly")]
+#[cfg_attr(miri, ignore)]
+#[ignore = "https://github.com/rust-lang/rust/issues/126836"]
+fn panics() {
+    let _m = FOO_MTX.lock();
+    unsafe{ mock_ffi::foo(1,2,3) };
 }


### PR DESCRIPTION
Begining within Rust 1.81
(https://github.com/rust-lang/rust/issues/74990) Rust will abort when attempting to unwind a panic across an "extern C" boundary.  Previously it was technically UB, but it worked and Mockall relied on it.  Now, unwinding across such a boundary requires the "extern C-unwind" ABI. Use that ABI in the generated code.

However, don't use that ABI when mocking a C variadic function.  That doesn't work, due to https://github.com/rust-lang/rust/issues/126836 .

Fixes #584