### PR TITLE
Fix the build on Rust 1.73.0 and nearby versions

### DIFF
--- a/mockall_derive/build.rs
+++ b/mockall_derive/build.rs
@@ -3,5 +3,5 @@ fn main() {
     println!("cargo:rerun-if-changed=build.rs");
 
     // Quiet rustc's helpful lint.  reprocheck is defined in CI.
-    println!("cargo::rustc-check-cfg=cfg(reprocheck)");
+    println!("cargo:rustc-check-cfg=cfg(reprocheck)");
 }


### PR DESCRIPTION
Rust 1.71 and earlier ignored build script outputs like "cargo::name=value".  Rust nightly from around 5-May-2024 complains about unexpected_cfgs , and the suggested solution is to add a "cargo::name=value" output to the build script.  But intermediate Rust versions including 1.73.0 treat that syntax as an error.  Happily, all tested Rust versions accept and understand "cargo:name=value" (note the single colon).

This fixes a regression introduced by #574 and not yet released.