### PR TITLE
Use the C-unwind ABI when mocking variadic functions

### DIFF
--- a/mockall/tests/automock_foreign_c_variadic.rs
+++ b/mockall/tests/automock_foreign_c_variadic.rs
@@ -29,7 +29,7 @@ fn mocked_c_variadic() {
 #[test]
 #[cfg(feature = "nightly")]
 #[cfg_attr(miri, ignore)]
-#[ignore = "https://github.com/rust-lang/rust/issues/126836"]
+#[should_panic(expected = "No matching expectation found")]
 fn panics() {
     let _m = FOO_MTX.lock();
     unsafe{ mock_ffi::foo(1,2,3) };

--- a/mockall_derive/src/mock_item.rs
+++ b/mockall_derive/src/mock_item.rs
@@ -98,13 +98,9 @@ impl From<MockableModule> for MockItemModule {
                             //
                             // BUT, use C-unwind instead of C, so we can panic
                             // from the mock function (rust-lang/rust #74990)
-                            //
-                            // BUT, don't use C-unwind for variadic functions,
-                            // because it doesn't work yet (rust-lang/rust
-                            // #126836)
                             let needs_c_unwind = if let Some(n) = &ifm.abi.name
                             {
-                                n.value() == "C" && f.sig.variadic.is_none()
+                                n.value() == "C"
                             } else {
                                 false
                             };


### PR DESCRIPTION
Now that https://github.com/rust-lang/rust/issues/126836 is fixed.