### PR TITLE
Add compatibility with auto_enums

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+- Add the ability to mock methods that use `#[auto_enum]`, from the
+  `auto_enums` crate.  But only for methods that use RPIT; Mockall can't yet
+  handle syntax like `-> Result<(), impl T>`
+  ([#590](https://github.com/asomers/mockall/pull/590))
+
 - Add the ability to mock methods that use `#[inline]` or `#[cold]`, and
   methods or traits that use `#[must_use]`.
   ([#555](https://github.com/asomers/mockall/pull/555))

--- a/mockall/Cargo.toml
+++ b/mockall/Cargo.toml
@@ -47,6 +47,7 @@ mockall_derive = { version = "=0.12.1", path = "../mockall_derive" }
 
 [dev-dependencies]
 async-trait = "0.1.38"
+auto_enums = "0.8.5"
 futures = "0.3.7"
 mockall_double = { version = "^0.3.1", path = "../mockall_double" }
 serde = "1.0.113"

--- a/mockall/tests/auto_enum.rs
+++ b/mockall/tests/auto_enum.rs
@@ -1,0 +1,35 @@
+// vim: tw=80
+//! A method that uses `#[auto_enum]`, from the auto_enums crate.
+#![deny(warnings)]
+
+use auto_enums::auto_enum;
+use futures::{Future, FutureExt, future};
+use mockall::*;
+
+pub struct Foo{}
+
+#[automock]
+impl Foo {
+    #[auto_enum(Future)]
+    pub fn sign(&self, x: i32) -> impl Future<Output=i32>
+    {
+        if x > 0 {
+            future::ready(1)
+        } else {
+            future::ready(1).then(|_| future::ready(-1))
+        }
+    }
+}
+
+#[test]
+fn rpit() {
+    let mut mock = MockFoo::new();
+    mock.expect_sign()
+        .returning(|_| {
+            Box::pin(future::ready(42))
+        });
+    let r = mock.sign(101)
+        .now_or_never()
+        .unwrap();
+    assert_eq!(42, r);
+}

--- a/mockall/tests/automock_impl_future.rs
+++ b/mockall/tests/automock_impl_future.rs
@@ -1,5 +1,5 @@
 // vim: tw=80
-//! A trait with a constructor method that returns impl Future<...>.
+//! A trait with a method that returns impl Future<...>.
 //!
 //! This needs special handling, because Box<dyn Future<...>> is pretty useless.
 //! You need Pin<Box<dyn Future<...>>> instead.

--- a/mockall_derive/src/lib.rs
+++ b/mockall_derive/src/lib.rs
@@ -796,6 +796,10 @@ impl<'a> AttrFormatter<'a> {
                     false
                 } else if *i.as_ref().unwrap() == "must_use" {
                     self.must_use
+                } else if *i.as_ref().unwrap() == "auto_enum" {
+                    // Ignore auto_enum, because we transform the return value
+                    // into a trait object.
+                    false
                 } else {
                     true
                 }


### PR DESCRIPTION
Make Mockall compatible with the use of the auto_enums crate for functions that use RPIT, like this:
```rust
    #[auto_enum(Future)]
    fn foo() -> impl Future<Output=()> {
        ...
    }
```