### PR TITLE
Enable the automock_gat test without the nightly feature

### DIFF
--- a/mockall/tests/automock_gat.rs
+++ b/mockall/tests/automock_gat.rs
@@ -2,34 +2,28 @@
 //! automock a trait with Generic Associated Types
 #![deny(warnings)]
 
-use cfg_if::cfg_if;
+use mockall::*;
 
-cfg_if! {
-    if #[cfg(feature = "nightly")] {
-        use mockall::*;
+// The lifetime must have the same name as in the next() method.
+#[automock(type Item=&'a u32;)]
+trait LendingIterator {
+    type Item<'a> where Self: 'a;
 
-        // The lifetime must have the same name as in the next() method.
-        #[automock(type Item=&'a u32;)]
-        trait LendingIterator {
-            type Item<'a> where Self: 'a;
+    // Clippy doesn't know that Mockall will need the lifetime when it
+    // expands the macro.
+    #[allow(clippy::needless_lifetimes)]
+    fn next<'a>(&'a mut self) -> Option<Self::Item<'a>>;
+}
 
-            // Clippy doesn't know that Mockall will need the lifetime when it
-            // expands the macro.
-            #[allow(clippy::needless_lifetimes)]
-            fn next<'a>(&'a mut self) -> Option<Self::Item<'a>>;
-        }
-
-        // It isn't possible to safely set an expectation for a non-'static
-        // return value (because the mock object doesn't have any lifetime
-        // parameters itself), but unsafely setting such an expectation is a
-        // common use case.
-        #[test]
-        fn return_const() {
-            let mut mock = MockLendingIterator::new();
-            let x = 42u32;
-            let xstatic: &'static u32 = unsafe{ std::mem::transmute(&x) };
-            mock.expect_next().return_const(Some(xstatic));
-            assert_eq!(42u32, *mock.next().unwrap());
-        }
-    }
+// It isn't possible to safely set an expectation for a non-'static
+// return value (because the mock object doesn't have any lifetime
+// parameters itself), but unsafely setting such an expectation is a
+// common use case.
+#[test]
+fn return_const() {
+    let mut mock = MockLendingIterator::new();
+    let x = 42u32;
+    let xstatic: &'static u32 = unsafe{ std::mem::transmute(&x) };
+    mock.expect_next().return_const(Some(xstatic));
+    assert_eq!(42u32, *mock.next().unwrap());
 }


### PR DESCRIPTION
Now that our MSRV is 1.71.0

Fixes #436