### PR TITLE
Support mocking multiple traits with same name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [ Unreleased ] - ReleaseDate
+
+### Fixed
+
+- Fixed naming conflict when mocking multiple traits with same name but from
+  different modules.
+  ([#601](https://github.com/asomers/mockall/pull/601))
+
 ## [ 0.13.0 ] - 2024-07-21
 
 ### Added

--- a/mockall/tests/mock_multiple_traits_same_name.rs
+++ b/mockall/tests/mock_multiple_traits_same_name.rs
@@ -1,0 +1,27 @@
+// vim: tw=80
+//! A struct that implements multiple traits with same name
+#![deny(warnings)]
+
+use mockall::*;
+
+mod a {
+    pub trait Trait {}
+}
+
+mod b {
+    pub trait Trait {}
+}
+
+mock! {
+    MultiTrait {}
+    impl a::Trait for MultiTrait {}
+    impl b::Trait for MultiTrait {}
+}
+
+#[test]
+fn new() {
+    fn foo<T: a::Trait + b::Trait>(_t: T) {}
+
+    let mock = MockMultiTrait::new();
+    foo(mock);
+}


### PR DESCRIPTION
An attempt to solve https://github.com/asomers/mockall/issues/600.

Not really sure about backward compatibility. Should be fine as we only change the generation of a private identifier. But it could cause issues if either a length limit is reached or a there's a name collision with a different ident.