### PR TITLE
Don't use #[no_mangle] when mocking foreign C functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,21 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [ Unreleased ] - ReleaseDate
+
+### Fixed
+
+- Fixed crates that export both real functions and mock versions of those
+  functions, where the real functions have the C ABI.
+  ([#603](https://github.com/asomers/mockall/pull/603))
+
+### Removed
+
+- Removed the ability to call mock versions of FFI C-ABI functions directly from
+  C.  Now, users who wish to do that must manually add a wrapper providing the C
+  ABI, as shown in mockall/examples/call-from-c.rs .
+  ([#603](https://github.com/asomers/mockall/pull/603))
+
 ## [ 0.14.0 ] - 2025-11-22
 
 ### Added

--- a/mockall/examples/call-from-c.rs
+++ b/mockall/examples/call-from-c.rs
@@ -1,0 +1,46 @@
+// vim: tw=80
+//! An example of how to use Mockall to create mock functions that can be called
+//! from C
+use mockall::automock;
+#[cfg(test)]
+use mockall::predicate::eq;
+
+#[automock]
+pub mod ffi {
+    extern "C" {
+        // This is provided by the OS's C library
+        pub fn isupper(c: i32) -> i32;
+    }
+}
+
+/// But in the test configuration, we override the OS's isupper with a
+/// C-compatible wrapper that calls a mock function.
+#[cfg(test)]
+#[no_mangle]
+pub unsafe extern "C-unwind" fn isupper(c: i32) -> i32 {
+    mock_ffi::isupper(c)
+}
+
+/// This function is written in Rust for our convenience, but it has C linkage
+/// and no Rust name mangling.  In this test, it serves as a proxy for a C
+/// function.
+#[no_mangle]
+pub extern "C" fn some_c_func(c: i32) -> i32 {
+    unsafe{ffi::isupper(c)}
+}
+
+fn main() {
+    // In non-test code, we can call the C function, and it will call the OS's
+    // isupper function like normal.
+    println!("isupper(A) = {}", some_c_func(65));
+}
+
+// But in test mode, the OS's isupper symbol is overridden by our own.
+#[test]
+fn t() {
+    let ctx = mock_ffi::isupper_context();
+    ctx.expect()
+        .with(eq(42))
+        .return_const(1);
+    assert_eq!(1, some_c_func(42));
+}

--- a/mockall/tests/automock_foreign_c.rs
+++ b/mockall/tests/automock_foreign_c.rs
@@ -5,48 +5,56 @@ use mockall::*;
 use std::sync::Mutex;
 
 #[automock]
-mod ffi {
+pub mod ffi {
     extern "C" {
-        pub(super) fn foo(x: u32) -> i64;
+        // These are provided by the C library
+        pub(super) fn isupper(c: i32) -> i32;
+        pub fn islower(c: i32) -> i32;
     }
 }
 
-static FOO_MTX: Mutex<()> = Mutex::new(());
+#[allow(clippy::missing_safety_doc)]
+#[no_mangle]
+pub unsafe extern "C-unwind" fn islower(c: i32) -> i32 {
+    mock_ffi::islower(c)
+}
+const MOCK_ISUPPER: unsafe extern "C-unwind" fn(i32) -> i32 = mock_ffi::isupper;
+
+static ISUPPER_MTX: Mutex<()> = Mutex::new(());
 
 // Ensure we can still use the original mocked function
+#[test]
 pub fn normal_usage() {
-    let _m = FOO_MTX.lock();
-    unsafe {
-        ffi::foo(42);
-    }
+    let _m = ISUPPER_MTX.lock();
+    assert!(0 != unsafe { ffi::isupper('A' as i32)});
+    assert_eq!(0, unsafe { ffi::isupper('a' as i32)});
 }
 
 #[test]
-#[should_panic(expected = "mock_ffi::foo(5): No matching expectation found")]
+#[should_panic(expected = "mock_ffi::isupper(5): No matching expectation found")]
 fn with_no_matches() {
-    let _m = FOO_MTX.lock();
-    let ctx = mock_ffi::foo_context();
+    let _m = ISUPPER_MTX.lock();
+    let ctx = mock_ffi::isupper_context();
     ctx.expect()
         .with(predicate::eq(4))
-        .returning(i64::from);
-    unsafe{ mock_ffi::foo(5) };
+        .returning(i32::from);
+    unsafe{ mock_ffi::isupper(5) };
 }
 
 #[test]
 fn returning() {
-    let _m = FOO_MTX.lock();
-    let ctx = mock_ffi::foo_context();
-    ctx.expect().returning(i64::from);
-    assert_eq!(42, unsafe{mock_ffi::foo(42)});
+    let _m = ISUPPER_MTX.lock();
+    let ctx = mock_ffi::isupper_context();
+    ctx.expect().returning(i32::from);
+    assert_eq!(42, unsafe{mock_ffi::isupper(42)});
 }
 
 /// Ensure that the mock function can be called from C by casting it to a C
 /// function pointer.
 #[test]
 fn c_abi() {
-    let _m = FOO_MTX.lock();
-    let ctx = mock_ffi::foo_context();
-    ctx.expect().returning(i64::from);
-    let p: unsafe extern "C-unwind" fn(u32) -> i64 = mock_ffi::foo;
-    assert_eq!(42, unsafe{p(42)});
+    let _m = ISUPPER_MTX.lock();
+    let ctx = mock_ffi::isupper_context();
+    ctx.expect().returning(i32::from);
+    assert_eq!(42, unsafe{MOCK_ISUPPER(42)});
 }

--- a/mockall_derive/src/mock_function.rs
+++ b/mockall_derive/src/mock_function.rs
@@ -512,22 +512,6 @@ impl MockFunction {
             };
             (&self.call_vis, dead_code)
         };
-        // Add #[no_mangle] attribute to preserve the function name
-        // as-is, without mangling, for compatibility with C functions.
-        let no_mangle = if let Some(ref abi) = self.sig.abi {
-            if let Some(ref name) = abi.name {
-                if name.value().ne("Rust") {
-                    quote!(#[no_mangle])
-                } else {
-                    quote!()
-                }
-            } else {
-                // This is the same as extern "C"
-                quote!(#[no_mangle])
-            }
-        } else {
-            quote!()
-        };
         let substruct_obj: TokenStream = if let Some(trait_) = &self.trait_ {
             let ident = format_ident!("{}_expectations", trait_);
             quote!(#ident.)
@@ -553,7 +537,6 @@ impl MockFunction {
                 // Don't add a doc string.  The original is included in #attrs
                 #(#attrs)*
                 #dead_code
-                #no_mangle
                 #vis #sig {
                     #deref {
                         let __mockall_guard = #outer_mod_path::get_expectations()
@@ -578,7 +561,6 @@ impl MockFunction {
                 // Don't add a doc string.  The original is included in #attrs
                 #(#attrs)*
                 #dead_code
-                #no_mangle
                 #vis #sig {
                     #deref self.#substruct_obj #name.#call #tbf(#(#call_exprs,)*)
                 }


### PR DESCRIPTION
Don't use #[no_mangle] when mocking foreign C functions
    
That causes the Rust function to have exactly the same name as the
original, so the linker can't link to both.  That is, it prevents a
program from mocking a C function and still calling the original.
    
This change partially reverts #504.  Now, users wishing to call mock
functions directly from C must add a one-line wrapper function with the
C ABI, as shown in the call-from-c.rs example.
    
Fixes #602