### PR TITLE
Fix missing_docs lints with the latest nightly

### DIFF
--- a/mockall/tests/mock_docs.rs
+++ b/mockall/tests/mock_docs.rs
@@ -1,14 +1,16 @@
 // vim: tw=80
+//! mock! should allow doc comments in all reasonable positions.  This test
+//! ensures that the code will compile.  mockall_derive has a unit test to
+//! ensure that the doc comments are correctly placed.
+
 #![deny(missing_docs)]
 #![deny(warnings)]
 
 use mockall::*;
 
-// mock! should allow doc comments in all reasonable positions.  This test
-// ensures that the code will compile.  mockall_derive has a unit test to ensure
-// that the doc comments are correctly placed.
-
+/// Docs for a real (not-mock) trait
 pub trait Tr {
+    /// Some method
     fn bar(&self);
 }
 


### PR DESCRIPTION
Previously nightly compilers would ignore missing_docs in integration tests, but no more.