### PR TITLE
Clippy cleanup

### DIFF
--- a/mockall/tests/automock_nonpub_methods.rs
+++ b/mockall/tests/automock_nonpub_methods.rs
@@ -2,7 +2,7 @@
 //! Using automock on a struct with private methods should not result in any
 //! "dead_code" warnings.  Such methods are often private helpers used only by
 //! other public methods.
-#[deny(dead_code)]
+#![deny(dead_code)]
 
 pub mod mymod {
     use mockall::automock;


### PR DESCRIPTION
Fix a clippy::empty_line_after_outer_attr lint