### PR TITLE
Suppress the clippy::ref_option warning in generated code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- Suppress the `#[clippy::ref_option]` warning, new in Rust 1.83.0, in
+  generated code.
+  ([#618](https://github.com/asomers/mockall/pull/618))
+
 - When mocking functions with a closure argument, but not using
   `#[concretize]`, include any additional trait bounds in the trait object
   argument passed to `.with` and `.returning.

--- a/mockall/tests/ref_option.rs
+++ b/mockall/tests/ref_option.rs
@@ -1,0 +1,7 @@
+//! Mockall should suppress clippy::ref_option warnings in generated code.
+#![warn(clippy::ref_option)]
+
+#[mockall::automock]
+pub trait Store {
+    fn find(&self, name: Option<String>) -> bool;
+}

--- a/mockall_derive/src/mock_function.rs
+++ b/mockall_derive/src/mock_function.rs
@@ -979,6 +979,7 @@ impl ToTokens for Common<'_> {
                 }
 
                 #[allow(clippy::ptr_arg)]
+                #[allow(clippy::ref_option)]
                 fn matches #lg (&self, #( #argnames: &#predty, )*) -> bool {
                     self.matcher.lock().unwrap().matches(#(#argnames, )*)
                 }
@@ -1118,6 +1119,7 @@ impl ToTokens for CommonExpectationMethods<'_> {
 
             /// Validate this expectation's matcher.
             #[allow(clippy::ptr_arg)]
+            #[allow(clippy::ref_option)]
             fn matches #lg (&self, #(#argnames: &#predty, )*) -> bool {
                 self.common.matches(#(#argnames, )*)
             }
@@ -1719,6 +1721,7 @@ impl ToTokens for Matcher<'_> {
             }
             impl #ig Matcher #tg #wc {
                 #[allow(clippy::ptr_arg)]
+                #[allow(clippy::ref_option)]
                 fn matches #lg (&self, #( #argnames: &#predty, )*) -> bool {
                     match self {
                         Matcher::Always => true,


### PR DESCRIPTION
Fixes #617