### PR TITLE
Suppress `single-use-lifetimes` warnings in generated code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [ Unreleased ] - ReleaseDate
+
+### Fixed
+
+- Suppress `single-use-lifetimes` lints in the generated code, for cases where
+  the orginal code wouldn't have triggered the warning.
+  ([#627](https://github.com/asomers/mockall/pull/627))
+
 ## [ 0.13.1 ] - 2024-11-17
 
 ### Fixed

--- a/mockall/tests/mock_life0.rs
+++ b/mockall/tests/mock_life0.rs
@@ -2,6 +2,7 @@
 //! mock a method whose self parameter has an explicit lifetime
 //! https://github.com/asomers/mockall/issues/95
 #![deny(warnings)]
+#![allow(single_use_lifetimes)] // The lifetime is the whole point of this test
 
 use mockall::*;
 

--- a/mockall/tests/single-use-lifetime.rs
+++ b/mockall/tests/single-use-lifetime.rs
@@ -1,0 +1,22 @@
+// vim: tw=80
+//! Mock a function with a lifetime parameter that isn't single-use, but becomes
+//! single-use in the generated code.
+#![deny(warnings)]
+#![deny(single_use_lifetimes)]
+
+use mockall::*;
+
+#[automock]
+pub trait MyTrait {
+    #[allow(clippy::needless_lifetimes)]
+    fn get<'a>(&'a mut self, data: i32) -> std::io::Result<&'a str>;
+}
+
+#[test]
+fn returning() {
+    let mut mock = MockMyTrait::new();
+    mock.expect_get()
+        .returning(|_data| Err(std::io::Error::from_raw_os_error(42)));
+
+    mock.get(0x1a7ebabe).unwrap_err();
+}

--- a/mockall_derive/src/mock_function.rs
+++ b/mockall_derive/src/mock_function.rs
@@ -1222,6 +1222,7 @@ impl ToTokens for CommonExpectationsMethods<'_> {
                     Self(Vec::new())
                 }
             }
+            #[allow(single_use_lifetimes)]
             impl #ig Default for Expectations #tg #wc
             {
                 fn default() -> Self {
@@ -1806,6 +1807,7 @@ impl ToTokens for RefRfunc<'_> {
                 }
             }
 
+            #[allow(single_use_lifetimes)]
             impl #ig std::default::Default for Rfunc #tg #wc
             {
                 fn default() -> Self {
@@ -1896,6 +1898,7 @@ impl ToTokens for RefMutRfunc<'_> {
                 }
             }
 
+            #[allow(single_use_lifetimes)]
             impl #ig std::default::Default for Rfunc #tg #wc
             {
                 fn default() -> Self {
@@ -1984,6 +1987,7 @@ impl ToTokens for StaticRfunc<'_> {
                 }
             }
 
+            #[allow(single_use_lifetimes)]
             impl #ig std::default::Default for Rfunc #tg #wc
             {
                 fn default() -> Self {
@@ -2047,6 +2051,7 @@ impl ToTokens for RefExpectation<'_> {
 
                 #common_methods
             }
+            #[allow(single_use_lifetimes)]
             impl #ig Default for Expectation #tg #wc
             {
                 fn default() -> Self {
@@ -2135,6 +2140,7 @@ impl ToTokens for RefMutExpectation<'_> {
 
                 #common_methods
             }
+            #[allow(single_use_lifetimes)]
             impl #ig Default for Expectation #tg #wc
             {
                 fn default() -> Self {
@@ -2309,6 +2315,7 @@ impl ToTokens for StaticExpectation<'_> {
 
                 #common_methods
             }
+            #[allow(single_use_lifetimes)]
             impl #ig Default for Expectation #tg #wc
             {
                 fn default() -> Self {


### PR DESCRIPTION
Fixes #626