### PR TITLE
Suppress a new clippy::unnecessary-map-or warning

### DIFF
--- a/mockall_derive/src/mock_function.rs
+++ b/mockall_derive/src/mock_function.rs
@@ -266,6 +266,7 @@ impl<'a> Builder<'a> {
         let mut return_ref = false;
         let mut return_refmut = false;
         if let Type::Reference(ref tr) = &output {
+            #[allow(clippy::unnecessary_map_or)]
             if tr.lifetime.as_ref().map_or(true, |lt| lt.ident != "static")
             {
                 if tr.mutability.is_none() {


### PR DESCRIPTION
Clippy's suggested fix requires a 1.82.0 MSRV.  So for now, merely suppress it.

Issue #628