### PR TITLE
Quiet a clippy::literal_string_with_formatting_args warning

### DIFF
--- a/mockall_derive/src/mock_function.rs
+++ b/mockall_derive/src/mock_function.rs
@@ -636,6 +636,7 @@ impl MockFunction {
         } else {
             format!("{}::{}", self.mod_ident, self.sig.ident)
         };
+        #[allow(clippy::literal_string_with_formatting_args)]
         let fields = vec!["{:?}"; argnames.len()].join(", ");
         let fstr = format!("{name}({fields})");
         quote!(std::format!(#fstr, #((&&::mockall::ArgPrinter(&#argnames)).debug_string()),*))


### PR DESCRIPTION
As this crate is a proc macro, the code was generating a formatting string to emit in the generated code.  So the warning is a false alarm.