### PR TITLE
fix: Make macro crate references be a valid identifier

### DIFF
--- a/mockall/tests/mock_struct_in_macro.rs
+++ b/mockall/tests/mock_struct_in_macro.rs
@@ -1,0 +1,26 @@
+// vim: tw=80
+#![deny(warnings)]
+
+pub trait Bar {
+    fn foo(&self, x: u32) -> i64;
+}
+
+macro_rules! mock_foo {
+    ($struct:ident) => {
+        mockall::mock! {
+            pub $struct {}
+            impl $crate::mockall::tests::mock_struct_in_macro::Bar for $struct {
+                fn foo(&self, x: u32) -> i64;
+            }
+        }
+    };
+}
+
+mock_foo!(Foo);
+
+#[test]
+fn return_const() {
+    let mut mock = MockFoo::new();
+    mock.expect_foo().return_const(6);
+    assert_eq!(6, mock.foo(5));
+}


### PR DESCRIPTION
Authored a failing test to demonstrate the issue

This issue was introduced in [v0.13.1](https://github.com/asomers/mockall/releases/tag/v0.13.1)