### PR TITLE
No longer poison a Context object's internal `Mutex` when panicing

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -14,7 +14,7 @@ common: &COMMON
 task:
   name: MSRV
   container:
-    image: rust:1.71.0
+    image: rust:1.77.0
   cargo_lock_script:
     - cp Cargo.lock.msrv Cargo.lock
   << : *COMMON

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,16 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [ Unreleased ] - ReleaseDate
 
+### Changed
+
+- The MSRV is now Rust 1.77.0.
+  ([#650](https://github.com/asomers/mockall/pull/650))
+
 ### Fixed
+
+- No longer poison a Context object's internal `Mutex` when panicing, even when
+  using a stable Rust compiler.
+  ([#650](https://github.com/asomers/mockall/pull/650))
 
 - Suppress `single-use-lifetimes` lints in the generated code, for cases where
   the orginal code wouldn't have triggered the warning.

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ See the [API docs](https://docs.rs/mockall) for more information.
 
 # Minimum Supported Rust Version (MSRV)
 
-Mockall is supported on Rust 1.71.0 and higher.  Mockall's MSRV will not be
+Mockall is supported on Rust 1.77.0 and higher.  Mockall's MSRV will not be
 changed in the future without bumping the major or minor version.
 
 # License

--- a/mockall/Cargo.toml
+++ b/mockall/Cargo.toml
@@ -9,7 +9,7 @@ categories = ["development-tools::testing"]
 keywords = ["mock", "mocking", "testing"]
 documentation = "https://docs.rs/mockall"
 edition = "2021"
-rust-version = "1.71"
+rust-version = "1.77"
 description = """
 A powerful mock object library for Rust.
 """

--- a/mockall_derive/src/mock_function.rs
+++ b/mockall_derive/src/mock_function.rs
@@ -1583,13 +1583,7 @@ impl ToTokens for Context<'_> {
         #[cfg(feature = "nightly_derive")]
         let must_use = quote!();
 
-        #[cfg(not(feature = "nightly_derive"))]
-        let clear_poison = quote!();
-        #[cfg(feature = "nightly_derive")]
-        let clear_poison = quote!(
-            #[allow(clippy::incompatible_msrv)]
-            get_expectations().clear_poison();
-        );
+        let clear_poison = quote!(get_expectations().clear_poison(););
 
         quote!(
             /// Manages the context for expectations of static methods.


### PR DESCRIPTION
Even when using a stable Rust compiler.  This raises MSRV to 1.77.0.