### PR TITLE
Make use of cargo::rustc-check-cfg

### DIFF
--- a/mockall/Cargo.toml
+++ b/mockall/Cargo.toml
@@ -9,7 +9,7 @@ categories = ["development-tools::testing"]
 keywords = ["mock", "mocking", "testing"]
 documentation = "https://docs.rs/mockall"
 edition = "2021"
-rust-version = "1.77"
+rust-version = "1.77.0"
 description = """
 A powerful mock object library for Rust.
 """

--- a/mockall/build.rs
+++ b/mockall/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("cargo::rustc-check-cfg=cfg(target_os, values(\"multics\"))");
+}

--- a/mockall/tests/automock_attrs.rs
+++ b/mockall/tests/automock_attrs.rs
@@ -1,7 +1,6 @@
 // vim: tw=80
 //! Attributes are applied to the mock object, too.
 #![deny(warnings)]
-#![allow(unexpected_cfgs)] // multics is deliberately always false
 
 use mockall::*;
 

--- a/mockall/tests/cfg_attr_concretize.rs
+++ b/mockall/tests/cfg_attr_concretize.rs
@@ -1,7 +1,6 @@
 // vim: tw=80
 //! #[concretize] can be used inside of #[cfg_attr()]`
 #![deny(warnings)]
-#![allow(unexpected_cfgs)] // multics is deliberately always false
 
 use std::path::{Path, PathBuf};
 


### PR DESCRIPTION
Rather than disabling the unexpected-cfg lint.

Fixes #573