### PR TITLE
Allow methods on mocks to be called with a range of times in a Sequence

### DIFF
--- a/mockall/src/lib.rs
+++ b/mockall/src/lib.rs
@@ -1697,18 +1697,31 @@ impl Key {
 #[doc(hidden)]
 pub struct SeqHandle {
     inner: Arc<SeqInner>,
-    seq: usize
+    seq: usize,
+    min_seq: usize,
+    has_called_state: bool,
 }
 
 impl SeqHandle {
+    /// Tell the Sequence that this expectation has been used.
+    pub fn called(&self) {
+        self.inner.called(self.seq, self.min_seq, self.has_called_state);
+    }
+
     /// Tell the Sequence that this expectation has been fully satisfied
     pub fn satisfy(&self) {
-        self.inner.satisfy(self.seq);
+        self.inner.satisfy(self.seq, self.min_seq, self.has_called_state);
     }
 
     /// Verify that this handle was called in the correct order
     pub fn verify<F: Fn() -> String>(&self, desc: F) {
-        self.inner.verify(self.seq, desc);
+        self.inner.verify(self.seq, self.min_seq, self.has_called_state, desc);
+    }
+
+    /// Check whether the current handle is part of history (i.e. has been skipped or
+    /// has already taken place)
+    pub fn is_history(&self) -> bool {
+        self.inner.is_history(self.seq, self.has_called_state)
     }
 }
 
@@ -1718,23 +1731,43 @@ struct SeqInner {
 }
 
 impl SeqInner {
+    /// Record the call identified by `seq` as being called once.
+    fn called(&self, seq: usize, min_seq: usize, has_called_state: bool) {
+        let old_sl = self.satisfaction_level.fetch_max(seq, Ordering::Relaxed);
+        assert!(old_sl >= min_seq, "Method sequence violation.  Method was called without preceding methods having been satisfied.");
+        assert!(old_sl <= seq + if has_called_state { 1 } else { 0 } , "Method sequence violation.  Method was called while succeeding methods have been called.");
+    }
+
     /// Record the call identified by `seq` as fully satisfied.
-    fn satisfy(&self, seq: usize) {
-        let old_sl = self.satisfaction_level.fetch_add(1, Ordering::Relaxed);
-        assert_eq!(old_sl, seq, "Method sequence violation.  Was an already-satisfied method called another time?");
+    fn satisfy(&self, seq: usize, min_seq: usize, has_called_state: bool) {
+        let old_sl = self.satisfaction_level.fetch_max(seq + if has_called_state { 1 } else { 0 }, Ordering::Relaxed);
+        assert!(old_sl >= min_seq, "Method sequence violation.  Method was called without preceding methods having been satisfied.");
+        assert!(old_sl <= seq + if has_called_state { 1 } else { 0 } , "Method sequence violation.  Method was called while succeeding methods have been called.");
     }
 
     /// Verify that the call identified by `seq` was called in the correct order
-    fn verify<F: Fn() -> String>(&self, seq: usize, desc: F) {
-        assert_eq!(seq, self.satisfaction_level.load(Ordering::Relaxed),
-            "{}: Method sequence violation", &desc())
+    fn verify<F: Fn() -> String>(&self, seq: usize, min_seq: usize, has_called_state: bool, desc: F) {
+        let current_level = self.satisfaction_level.load(Ordering::Relaxed);
+        let max_seq = seq + if has_called_state { 1 } else { 0 };
+        
+        assert!(current_level >= min_seq,
+            "{}: Method sequence violation", &desc());
+        assert!(current_level <= max_seq,
+            "{}: Method sequence violation", &desc());
+    }
+
+    fn is_history(&self, seq: usize, has_called_state: bool) -> bool {
+        let current_level = self.satisfaction_level.load(Ordering::Relaxed);
+        let max_seq = seq + if has_called_state { 1 } else { 0 };
+
+        current_level > max_seq
     }
 }
 
 /// Used to enforce that mock calls must happen in the sequence specified.
-///
-/// Each expectation must expect to be called a fixed number of times.  Once
-/// satisfied, the next expectation in the sequence will expect to be called.
+/// 
+/// Sequences are performed greedily, and will try to use the earliest possible
+/// match.
 ///
 /// # Examples
 /// ```
@@ -1762,26 +1795,118 @@ impl SeqInner {
 /// mock0.foo();
 /// mock1.bar();
 /// ```
-///
-/// It is an error to add an expectation to a `Sequence` if its call count is
-/// unspecified.
-/// ```should_panic(expected = "with an exact call count")
+/// 
+/// The count is allowed to vary.
+/// ```
 /// # use mockall::*;
 /// #[automock]
 /// trait Foo {
 ///     fn foo(&self);
+///     fn bar(&self) -> u32;
 /// }
 /// let mut seq = Sequence::new();
 ///
-/// let mut mock = MockFoo::new();
-/// mock.expect_foo()
+/// let mut mock0 = MockFoo::new();
+/// let mut mock1 = MockFoo::new();
+///
+/// mock0.expect_foo()
+///     .times(1..4)
 ///     .returning(|| ())
-///     .in_sequence(&mut seq);  // panics!
+///     .in_sequence(&mut seq);
+///
+/// mock1.expect_bar()
+///     .times(1)
+///     .returning(|| 42)
+///     .in_sequence(&mut seq);
+///
+/// mock0.foo();
+/// mock0.foo();
+/// mock1.bar();
 /// ```
+/// 
+/// But, the previous count needs to suffice before a sequence may make progress
+/// ```should_panic
+/// # use mockall::*;
+/// #[automock]
+/// trait Foo {
+///     fn foo(&self);
+///     fn bar(&self) -> u32;
+/// }
+/// let mut seq = Sequence::new();
+///
+/// let mut mock0 = MockFoo::new();
+/// let mut mock1 = MockFoo::new();
+///
+/// mock0.expect_foo()
+///     .times(3..5)
+///     .returning(|| ())
+///     .in_sequence(&mut seq);
+///
+/// mock1.expect_bar()
+///     .times(1)
+///     .returning(|| 42)
+///     .in_sequence(&mut seq);
+///
+/// mock0.foo();
+/// mock0.foo();
+/// mock1.bar();
+/// ```
+/// 
+/// Furthermore, sequences are greedy, and will only perform the earliest element in sequence
+/// that is allowed. This results in the following example failing the second expectation, as
+/// the first expectation is used for both calls to `foo`.
+/// ```should_panic
+/// # use mockall::*;
+/// #[automock]
+/// trait Foo {
+///     fn foo(&self);
+///     fn bar(&self) -> u32;
+/// }
+/// let mut seq = Sequence::new();
+///
+/// let mut mock0 = MockFoo::new();
+///
+/// mock0.expect_foo()
+///     .returning(|| ())
+///     .in_sequence(&mut seq);
+///
+/// mock0.expect_foo()
+///     .times(1..)
+///     .returning(|| ())
+///     .in_sequence(&mut seq);
+///
+/// mock0.foo();
+/// mock0.foo();
+/// ```
+/// 
 #[derive(Default)]
 pub struct Sequence {
     inner: Arc<SeqInner>,
     next_seq: usize,
+    next_min_seq: usize,
+}
+
+/// Indicates whether the minimum call count is zero, one or more.
+/// 
+/// Used to ensure the handle count is incremented accordingly.
+#[doc(hidden)]
+pub enum MinimumCallCount {
+    /// Method may never be called
+    Zero,
+    /// Method has to be called at least once
+    One,
+    /// Method has to be called more than once
+    More
+}
+
+/// Infer what the minimum call count is
+#[doc(hidden)]
+pub fn times_to_minimum_call_count(times: &Times) -> MinimumCallCount {
+    match times.minimum() {
+        0 => MinimumCallCount::Zero,
+        1 => MinimumCallCount::One,
+        _ => MinimumCallCount::More,
+    }
 }
 
 impl Sequence {
@@ -1793,9 +1918,35 @@ impl Sequence {
     /// Not for public consumption, but it must be public so the generated code
     /// can call it.
     #[doc(hidden)]
-    pub fn next_handle(&mut self) -> SeqHandle {
-        let handle = SeqHandle{inner: self.inner.clone(), seq: self.next_seq};
-        self.next_seq += 1;
+    pub fn next_handle(&mut self, minimum_call_count: MinimumCallCount) -> SeqHandle {
+        let has_called_state = match minimum_call_count {
+            MinimumCallCount::Zero => false,
+            MinimumCallCount::One if self.next_seq != 0 => false,
+            _ => true,
+        };
+
+        let handle = SeqHandle{inner: self.inner.clone(), seq: self.next_seq, min_seq: self.next_min_seq, has_called_state};
+
+        match minimum_call_count {
+            MinimumCallCount::Zero => {
+                // We don't update min_seq, as we allow this state to be skipped.
+                // Only need to have a Satisfied state for this handle.
+                self.next_seq += 1;
+            },
+            MinimumCallCount::One if self.next_seq != 0 => {
+                // We need to be in at least state next_seq to ensure this handle has been performed at least once.
+                self.next_min_seq = self.next_seq;
+                // Only need to have a (4) Satisfied state for this handle, as (3) Called does not occur.
+                self.next_seq += 1;
+            },
+            // MinimumCallCount::More, or MinimumCallCount::One for the very first element in sequence.
+            _ => {
+                // We need to be in at least state next_seq to ensure this handle has been performed at least once.
+                self.next_min_seq = self.next_seq + 1;
+                // next_seq is (3) Called for the current handle, next_seq + 1 represents (4) Satisified.
+                self.next_seq += 2;
+            },
+        }
         handle
     }
 }

--- a/mockall/tests/mock_return_reference.rs
+++ b/mockall/tests/mock_return_reference.rs
@@ -56,17 +56,6 @@ mod sequence {
     use super::*;
 
     #[test]
-    #[should_panic(expected = "exact call count")]
-    fn ambiguous() {
-        let mut seq = Sequence::new();
-        let mut mock = MockFoo::new();
-        mock.expect_foo()
-            .times(1..3)
-            .in_sequence(&mut seq);
-        mock.foo(4);
-    }
-
-    #[test]
     #[should_panic(expected = "MockFoo::foo(4): Method sequence violation")]
     fn fail() {
         let mut seq = Sequence::new();
@@ -101,5 +90,16 @@ mod sequence {
 
         mock.foo(4);
         mock.bar();
+    }
+
+    #[test]
+    fn ok_variable_count() {
+        let mut seq = Sequence::new();
+        let mut mock = MockFoo::new();
+        mock.expect_foo()
+            .times(1..3)
+            .return_const(0)
+            .in_sequence(&mut seq);
+        mock.foo(4);
     }
 }

--- a/mockall/tests/mock_struct.rs
+++ b/mockall/tests/mock_struct.rs
@@ -225,17 +225,6 @@ mod sequence {
     use super::*;
 
     #[test]
-    #[should_panic(expected = "exact call count")]
-    fn ambiguous() {
-        let mut seq = Sequence::new();
-        let mut mock = MockFoo::new();
-        mock.expect_baz()
-            .times(1..3)
-            .in_sequence(&mut seq);
-        mock.baz();
-    }
-
-    #[test]
     #[should_panic(expected = "MockFoo::baz(): Method sequence violation")]
     fn fail() {
         let mut seq = Sequence::new();
@@ -272,6 +261,87 @@ mod sequence {
         mock.bar(0);
     }
 
+    #[test]
+    fn ok_variable_count() {
+        let mut seq = Sequence::new();
+        let mut mock = MockFoo::new();
+        mock.expect_baz()
+            .times(1..)
+            .returning(|| ())
+            .in_sequence(&mut seq);
+
+        mock.expect_bar()
+            .times(1..)
+            .returning(|_| ())
+            .in_sequence(&mut seq);
+
+        mock.baz();
+        mock.bar(0);
+    }
+
+    #[test]
+    fn ok_variable_count_skip() {
+        let mut seq = Sequence::new();
+        let mut mock = MockFoo::new();
+
+        // All of these may be skipped
+        mock.expect_bar()
+            .with(predicate::eq(0))
+            .returning(|_| ())
+            .in_sequence(&mut seq);
+        mock.expect_bar()
+            .with(predicate::eq(1))
+            .returning(|_| ())
+            .in_sequence(&mut seq);
+        mock.expect_bar()
+            .with(predicate::eq(2))
+            .returning(|_| ())
+            .in_sequence(&mut seq);
+
+        // This one may not        
+        mock.expect_baz()
+            .times(1..)
+            .returning(|| ())
+            .in_sequence(&mut seq);
+
+        mock.baz()
+    }
+
+    #[test]
+    #[should_panic]
+    fn err_variable_count_skip() {
+        let mut seq = Sequence::new();
+        let mut mock = MockFoo::new();
+
+        // All of these may be skipped
+        mock.expect_bar()
+            .with(predicate::eq(0))
+            .returning(|_| ())
+            .in_sequence(&mut seq);
+        mock.expect_bar()
+            .with(predicate::eq(1))
+            .returning(|_| ())
+            .in_sequence(&mut seq);
+        mock.expect_bar()
+            .with(predicate::eq(2))
+            .returning(|_| ())
+            .in_sequence(&mut seq);
+
+        // This one may not        
+        mock.expect_baz()
+            .times(1..)
+            .returning(|| ())
+            .in_sequence(&mut seq);
+
+        mock.expect_bar()
+            .with(predicate::eq(3))
+            .returning(|_| ())
+            .in_sequence(&mut seq);
+
+        // mock.baz()
+        mock.bar(3);
+    }
+
     /// When adding multiple calls of a single method, with the same arguments,
     /// to a sequence, expectations should not be called after they are done if
     /// there are more expectations to follow.
@@ -295,6 +365,49 @@ mod sequence {
         assert_eq!(1, mock.foo(0));
         assert_eq!(2, mock.foo(0));
         assert_eq!(3, mock.foo(0));
+    }
+
+    #[test]
+    fn single_method_variable_count() {
+        let mut seq = Sequence::new();
+        let mut mock = MockFoo::new();
+        mock.expect_foo()
+            .times(1..=2)
+            .in_sequence(&mut seq)
+            .returning(|_| 1);
+        mock.expect_foo()
+            .times(1)
+            .in_sequence(&mut seq)
+            .returning(|_| 3);
+
+        assert_eq!(1, mock.foo(0));
+        assert_eq!(1, mock.foo(0));
+        assert_eq!(3, mock.foo(0));
+    }
+
+    #[test]
+    fn single_method_variable_count_mixed() {
+        let mut seq = Sequence::new();
+        let mut mock = MockFoo::new();
+        mock.expect_baz()
+            .times(1..)
+            .returning(|| ())
+            .in_sequence(&mut seq);
+
+        mock.expect_bar()
+            .times(1..)
+            .returning(|_| ())
+            .in_sequence(&mut seq);
+
+        
+        mock.expect_baz()
+            .times(1..)
+            .returning(|| ())
+            .in_sequence(&mut seq);
+
+        mock.baz();
+        mock.bar(0);
+        mock.baz();
     }
 
 }

--- a/mockall_derive/src/mock_function.rs
+++ b/mockall_derive/src/mock_function.rs
@@ -967,20 +967,20 @@ impl ToTokens for Common<'_> {
                     self.verify_sequence(desc);
                     if ::mockall::ExpectedCalls::TooFew != self.times.is_satisfied() {
                         self.satisfy_sequence()
+                    } else {
+                        self.called_sequence()
                     }
                 }
 
                 fn in_sequence(&mut self, __mockall_seq: &mut ::mockall::Sequence)
                     -> &mut Self
                 {
-                    assert!(self.times.is_exact(),
-                        "Only Expectations with an exact call count have sequences");
-                    self.seq_handle = Some(__mockall_seq.next_handle());
+                    self.seq_handle = Some(__mockall_seq.next_handle(::mockall::times_to_minimum_call_count(&self.times)));
                     self
                 }
 
                 fn is_done(&self) -> bool {
-                    self.times.is_done()
+                    self.times.is_done() | self.is_history_sequence()
                 }
 
                 #[allow(clippy::ptr_arg)]
@@ -997,6 +997,20 @@ impl ToTokens for Common<'_> {
                 fn satisfy_sequence(&self) {
                     if let Some(__mockall_handle) = &self.seq_handle {
                         __mockall_handle.satisfy()
+                    }
+                }
+
+                fn called_sequence(&self) {
+                    if let Some(__mockall_handle) = &self.seq_handle {
+                        __mockall_handle.called()
+                    }
+                }
+
+                fn is_history_sequence(&self) -> bool {
+                    if let Some(__mockall_handle) = &self.seq_handle {
+                        __mockall_handle.is_history()
+                    } else {
+                        false
                     }
                 }
 


### PR DESCRIPTION
The requirement that the count on the times an expectation is an exact value is restricting, as I sometimes do not wish to define the amount of times a mocked method is called. For example, in one of my own codebases I have a method that is called at least once, but may be called multiple times without issue. As a simple minimum example of what works now:

```rust
let mut seq = Sequence::new();
let mut mock = MockFoo::new();
mock.expect_baz()
    .times(1..)
    .returning(|| ())
    .in_sequence(&mut seq);

mock.expect_bar()
    .times(1)
    .returning(|_| ())
    .in_sequence(&mut seq);

mock.baz();
mock.baz(); // repeated some random amount of times between 0..10
mock.bar(0);
```

The goal of this PR is to relax the exact value requirement, i.e., to allow a method to be called a variable number of times, within a range, including zero. It does so while maintaining the original behavior for exact cases, while enabling sequences to mark an earlier expectation as done to allow indefinite (with unset times()) to enforce ordering between calls.

For example, the following would work
```rust
let mut seq = Sequence::new();
let mut mock = MockFoo::new();

mock.expect_bar()
    .with(predicate::eq(0))
    .returning(|_| ())
    .in_sequence(&mut seq);
mock.expect_bar()
    .with(predicate::eq(1))
    .returning(|_| ())
    .in_sequence(&mut seq);
mock.expect_bar()
    .with(predicate::eq(2))
    .returning(|_| ())
    .in_sequence(&mut seq);

mock.bar(0);
mock.bar(0);
mock.bar(1);
mock.bar(1);
mock.bar(1);
mock.bar(2);
```

While altering the ordering would result in a failure:
```rust
let mut seq = Sequence::new();
let mut mock = MockFoo::new();

mock.expect_bar()
    .with(predicate::eq(0))
    .returning(|_| ())
    .in_sequence(&mut seq);
mock.expect_bar()
    .with(predicate::eq(1))
    .returning(|_| ())
    .in_sequence(&mut seq);
mock.expect_bar()
    .with(predicate::eq(2))
    .returning(|_| ())
    .in_sequence(&mut seq);

mock.bar(0);
mock.bar(1);
mock.bar(1);
mock.bar(1);
mock.bar(2);
mock.bar(0);
```