### PR TITLE
Fix CI's minver check

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -46,6 +46,6 @@ task:
   reproducibility_script:
     - env RUSTFLAGS="--cfg reprocheck" cargo check $CARGO_ARGS --all-targets
   minver_script:
-    - cargo update -Zminimal-versions
+    - cargo update -Zdirect-minimal-versions
     - cargo test $CARGO_ARGS
   before_cache_script: rm -rf $CARGO_HOME/registry/index

--- a/mockall_derive/Cargo.toml
+++ b/mockall_derive/Cargo.toml
@@ -28,9 +28,9 @@ nightly_derive = ["proc-macro2/nightly"]
 
 [dependencies]
 cfg-if = "1.0"
-proc-macro2 = "1.0.60"
-quote = "1.0"
-syn = { version = "2.0.9", features = ["extra-traits", "full"] }
+proc-macro2 = "1.0.75"
+quote = "1.0.35"
+syn = { version = "2.0.52", features = ["extra-traits", "full"] }
 
 [dev-dependencies]
 pretty_assertions = "1.3"

--- a/mockall_double/Cargo.toml
+++ b/mockall_double/Cargo.toml
@@ -28,6 +28,6 @@ nightly = ["proc-macro2/nightly"]
 
 [dependencies]
 cfg-if = "1.0"
-proc-macro2 = "1.0.60"
-quote = "1.0"
-syn = { version = "2.0", features = ["full"] }
+proc-macro2 = "1.0.75"
+quote = "1.0.35"
+syn = { version = "2.0.52", features = ["full"] }


### PR DESCRIPTION
A transitive dependency, itertools-1.10.0, no longer compiles with the latest nightly.  So there's no way to fix the build with -Zminimal-versions.  Instead, use -Zdirect-minimal-versions, which is usually better anyway.