### PR TITLE
Improve error message when call count is not specified in sequence

### DIFF
--- a/mockall_derive/src/mock_function.rs
+++ b/mockall_derive/src/mock_function.rs
@@ -974,7 +974,7 @@ impl ToTokens for Common<'_> {
                     -> &mut Self
                 {
                     assert!(self.times.is_exact(),
-                        "Only Expectations with an exact call count have sequences");
+                        "Only Expectations with an exact call count can have sequences");
                     self.seq_handle = Some(__mockall_seq.next_handle());
                     self
                 }


### PR DESCRIPTION
The error message "Only Expectations with an exact call count have sequences" is misleading.
Changed it to "Only Expectations with an exact call count **can** have sequences" to better reflect that only expectations with exact call counts are allowed to be placed in a sequence.