### PR TITLE
Fix mocking foreign functions with a variadic argument and no pattern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,12 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   the orginal code wouldn't have triggered the warning.
   ([#627](https://github.com/asomers/mockall/pull/627))
 
+- Fix mocking foreign functions with a variadic argument and no pattern, for
+  example `fn foo(...)` as opposed to `fn bar(x: ...)`.  That worked in prior
+  versions of Mockall only until Rust 1.93.0, which made such arguments illegal
+  for Rust functions.
+  ([#673](https://github.com/asomers/mockall/pull/673))
+
 ## [ 0.13.1 ] - 2024-11-17
 
 ### Fixed

--- a/mockall_derive/src/mockable_item.rs
+++ b/mockall_derive/src/mockable_item.rs
@@ -8,10 +8,21 @@ fn mockable_fn(mut item_fn: ItemFn) -> ItemFn {
     item_fn
 }
 
+/// Performs transformations on a Foreign Mod to make it mockable
+fn mockable_foreign_mod(mut ifm: ItemForeignMod) -> ItemForeignMod {
+    for item in &mut ifm.items {
+        if let ForeignItem::Fn(ref mut f) = item {
+            fix_elipses(&mut f.sig);
+        }
+    }
+    ifm
+}
+
 /// Performs transformations on an Item to make it mockable
 fn mockable_item(item: Item) -> Item {
     match item {
         Item::Fn(item_fn) => Item::Fn(mockable_fn(item_fn)),
+        Item::ForeignMod(ifm) => Item::ForeignMod(mockable_foreign_mod(ifm)),
         x => x
     }
 }


### PR DESCRIPTION
This worked in prior versions of Rust.  But starting with Rust 1.93.0, mockall would generate an error in cases like this:
```rust
pub mod ffi {
    extern "C" {
        pub fn foo(x: i32, ...) -> i32;
    }
}
```

Fix Mockall to generate correct code with any Rust version, whether or not the mocked function's signature includes a pattern.