### PR TITLE
feat: Add spy! macro and #[autospy] attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,41 @@ mod tests {
 }
 ```
 
+## Spying
+
+Mockall also supports spies.  A spy wraps a real implementation and
+delegates method calls to it by default, but allows you to override
+specific methods with expectations.  The easiest way is to use
+[`#[autospy]`](https://docs.rs/mockall/latest/mockall/attr.autospy.html).
+It can spy on most traits, or structs that only have a single `impl` block.
+For things it can't handle, there is [`spy!`](https://docs.rs/mockall/latest/mockall/macro.spy.html).
+
+```rust
+#[cfg(test)]
+use mockall::autospy;
+
+#[cfg_attr(test, autospy)]
+trait MyTrait {
+    fn foo(&self, x: u32) -> u32;
+}
+
+struct RealImpl;
+impl MyTrait for RealImpl {
+    fn foo(&self, x: u32) -> u32 { x * 2 }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn delegates_to_real() {
+        let spy = SpyMyTrait::new(RealImpl);
+        assert_eq!(spy.foo(21), 42);
+    }
+}
+```
+
 See the [API docs](https://docs.rs/mockall) for more information.
 
 # Minimum Supported Rust Version (MSRV)

--- a/mockall/src/lib.rs
+++ b/mockall/src/lib.rs
@@ -24,6 +24,11 @@
 //!   the preprogrammed return values supplied in the previous step.  Any
 //!   accesses contrary to your expectations will cause a panic.
 //!
+//! Mockall also supports *spies*.  A spy wraps a real implementation and
+//! delegates calls to it by default, but allows individual methods to be
+//! overridden.  Use [`#[autospy]`](attr.autospy.html) or [`spy!`] to
+//! create them.
+//!
 //! # User Guide
 //!
 //! * [`Getting started`](#getting-started)
@@ -46,6 +51,7 @@
 //! * [`Foreign functions`](#foreign-functions)
 //! * [`Debug`](#debug)
 //! * [`Async Traits`](#async-traits)
+//! * [`Spying`](#spying)
 //! * [`Crate features`](#crate-features)
 //! * [`Examples`](#examples)
 //!
@@ -1099,6 +1105,79 @@
 //! # fn main() {}
 //! ```
 //!
+//! ## Spying
+//!
+//! A spy wraps a real implementation and delegates method calls to it by
+//! default, while allowing individual methods to be overridden with
+//! expectations.  This is useful for partial mocking and call verification.
+//!
+//! The easiest way to create a spy is [`#[autospy]`](attr.autospy.html),
+//! which works on traits and struct impls:
+//!
+//! ```
+//! # use mockall::*;
+//! #[autospy]
+//! trait Foo {
+//!     fn foo(&self, x: u32) -> u32;
+//! }
+//!
+//! struct RealFoo;
+//! impl Foo for RealFoo {
+//!     fn foo(&self, x: u32) -> u32 { x * 2 }
+//! }
+//!
+//! # fn main() {
+//! use mockall::predicate::*;
+//!
+//! let mut spy = SpyFoo::new(RealFoo);
+//! assert_eq!(spy.foo(21), 42);     // delegates to real
+//!
+//! spy.expect_foo()
+//!     .times(1)
+//!     .returning(|x| x + 1);
+//! assert_eq!(spy.foo(5), 6);       // overridden
+//! spy.checkpoint();
+//!
+//! // Verify a call with specific arguments using calling_real()
+//! spy.expect_foo()
+//!     .with(eq(10))
+//!     .times(1)
+//!     .calling_real();
+//! assert_eq!(spy.foo(10), 20);     // delegates and verifies
+//! # }
+//! ```
+//!
+//! To spy on async methods, use `#[async_trait]`.  Native `async fn`
+//! and methods returning `impl Future` cannot be spied on directly.
+//!
+//! ```
+//! # use mockall::*;
+//! use async_trait::async_trait;
+//! use futures::executor::block_on;
+//!
+//! #[autospy]
+//! #[async_trait]
+//! trait AsyncFoo: Send + Sync {
+//!     async fn fetch(&self, id: u32) -> String;
+//! }
+//!
+//! struct RealService;
+//! #[async_trait]
+//! impl AsyncFoo for RealService {
+//!     async fn fetch(&self, id: u32) -> String {
+//!         format!("item-{id}")
+//!     }
+//! }
+//!
+//! # fn main() {
+//! let spy = SpyAsyncFoo::new(RealService);
+//! assert_eq!(block_on(spy.fetch(42)), "item-42");
+//! # }
+//! ```
+//!
+//! For more complex cases, there is [`spy!`].  See the [`spy!`] and
+//! [`#[autospy]`](attr.autospy.html) documentation for full details.
+//!
 //! ## Crate features
 //!
 //! Mockall has a **nightly** feature.  Currently this feature has two
@@ -1440,6 +1519,249 @@ pub use mockall_derive::concretize;
 /// # fn main() {}
 /// ```
 pub use mockall_derive::mock;
+
+/// Create a spy struct that wraps a real implementation.
+///
+/// A spy delegates method calls to the real implementation by default, but
+/// allows you to override specific methods with expectations.  This enables
+/// partial mocking and call verification.
+///
+/// Only trait methods can be spied on with `spy!`; inherent methods are not
+/// supported.  Use [`#[autospy]`](attr.autospy.html) on a struct impl block
+/// to spy on inherent methods.
+///
+/// # Examples
+///
+/// ```
+/// # use mockall_derive::spy;
+/// trait MyTrait {
+///     fn method(&self, x: u32) -> u32;
+/// }
+///
+/// struct RealImpl;
+/// impl MyTrait for RealImpl {
+///     fn method(&self, x: u32) -> u32 { x * 2 }
+/// }
+///
+/// spy! {
+///     Foo {
+///     }
+///     impl MyTrait for Foo {
+///         fn method(&self, x: u32) -> u32;
+///     }
+/// }
+///
+/// # fn main() {
+/// let real = RealImpl;
+/// let mut spy = SpyFoo::new(real);
+///
+/// // By default, delegates to the real implementation.
+/// assert_eq!(spy.method(21), 42);
+///
+/// // Override with an expectation.
+/// spy.expect_method()
+///     .returning(|x| x + 1);
+/// assert_eq!(spy.method(5), 6);
+/// # }
+/// ```
+///
+/// Use `calling_real()` to delegate to the real implementation while still
+/// verifying call counts:
+///
+/// ```
+/// # use mockall_derive::spy;
+/// trait Compute {
+///     fn compute(&self, x: u32) -> u32;
+/// }
+///
+/// struct Doubler;
+/// impl Compute for Doubler {
+///     fn compute(&self, x: u32) -> u32 { x * 2 }
+/// }
+///
+/// spy! {
+///     Calc {
+///     }
+///     impl Compute for Calc {
+///         fn compute(&self, x: u32) -> u32;
+///     }
+/// }
+///
+/// # fn main() {
+/// let mut spy = SpyCalc::new(Doubler);
+/// spy.expect_compute()
+///     .times(1)
+///     .calling_real();
+/// assert_eq!(spy.compute(5), 10);
+/// # }
+/// ```
+///
+/// The generated struct is generic: `SpyFoo<T>` where `T` must implement all
+/// the declared traits.  This allows wrapping different concrete types with
+/// the same spy definition.
+///
+/// The `spy!` macro also implements [`IntoSpy`] for any type satisfying the
+/// trait bounds, allowing you to write `real.into_spy()` instead of
+/// `SpyFoo::new(real)`:
+///
+/// ```
+/// # use mockall_derive::spy;
+/// use mockall::IntoSpy;
+///
+/// trait MyTrait { fn method(&self, x: u32) -> u32; }
+/// struct RealImpl;
+/// impl MyTrait for RealImpl { fn method(&self, x: u32) -> u32 { x * 2 } }
+/// spy! { Foo {} impl MyTrait for Foo { fn method(&self, x: u32) -> u32; } }
+///
+/// # fn main() {
+/// let real = RealImpl;
+/// let spy: SpyFoo<_> = real.into_spy();
+/// assert_eq!(spy.method(21), 42);
+/// # }
+/// ```
+///
+/// ## Limitations
+///
+/// * Only trait methods can be spied on.  Use
+///   [`#[autospy]`](attr.autospy.html) for inherent methods.
+/// * Static methods do not delegate; they behave like regular mock
+///   expectations.
+/// * Methods returning `impl Trait` (e.g. `impl Future`) cannot be
+///   spied on.  Use `#[async_trait]` for async methods instead.
+pub use mockall_derive::spy;
+
+/// Automatically generate spy types for traits and struct impls.
+///
+/// Similar to [`#[automock]`](attr.automock.html), but generates a spy struct
+/// (prefixed with "Spy") instead of a mock struct.  A spy delegates method
+/// calls to a wrapped real implementation by default, while allowing individual
+/// methods to be overridden with expectations.
+///
+/// # Examples
+///
+/// ## On a trait
+/// ```
+/// # use mockall::*;
+/// #[autospy]
+/// trait MyTrait {
+///     fn method(&self, x: u32) -> u32;
+/// }
+///
+/// struct RealImpl;
+/// impl MyTrait for RealImpl {
+///     fn method(&self, x: u32) -> u32 { x * 2 }
+/// }
+///
+/// # fn main() {
+/// let real = RealImpl;
+/// let spy = SpyMyTrait::new(real);
+/// assert_eq!(spy.method(21), 42);
+/// # }
+/// ```
+///
+/// ## On a struct impl
+/// ```
+/// # use mockall::*;
+/// struct Foo;
+///
+/// #[autospy]
+/// impl Foo {
+///     fn double(&self, x: u32) -> u32 { x * 2 }
+/// }
+///
+/// # fn main() {
+/// let spy = SpyFoo::new(Foo);
+/// assert_eq!(spy.double(21), 42);
+/// # }
+/// ```
+///
+/// ## With async_trait
+///
+/// To spy on async methods, combine `#[autospy]` with `#[async_trait]`.
+/// The `#[async_trait]` attribute must come after `#[autospy]`.
+///
+/// ```
+/// # use mockall::*;
+/// use async_trait::async_trait;
+/// use futures::executor::block_on;
+///
+/// #[autospy]
+/// #[async_trait]
+/// trait AsyncFoo: Send + Sync {
+///     async fn fetch(&self, id: u32) -> String;
+/// }
+///
+/// struct RealService;
+/// #[async_trait]
+/// impl AsyncFoo for RealService {
+///     async fn fetch(&self, id: u32) -> String {
+///         format!("item-{id}")
+///     }
+/// }
+///
+/// # fn main() {
+/// let mut spy = SpyAsyncFoo::new(RealService);
+/// assert_eq!(block_on(spy.fetch(1)), "item-1");
+///
+/// spy.expect_fetch()
+///     .returning(|_| "mocked".to_string());
+/// assert_eq!(block_on(spy.fetch(99)), "mocked");
+/// # }
+/// ```
+///
+/// ## Limitations
+///
+/// * `#[autospy]` does not support modules.  For module-level mocking,
+///   use [`mock!`] instead.
+/// * Static methods do not delegate; they behave like regular mock
+///   expectations.
+/// * Methods returning `impl Trait` (e.g. `impl Future`) cannot be
+///   spied on.  Use `#[async_trait]` for async methods instead.
+pub use mockall_derive::autospy;
+
+/// Constructor trait for building a spy from a real value.
+///
+/// This trait is automatically implemented by the [`spy!`] macro and
+/// [`#[autospy]`](attr.autospy.html) on the generated spy struct.  You
+/// normally won't call this directly — use the [`IntoSpy`] trait
+/// instead.
+pub trait SpyFrom<T> {
+    /// Create a spy wrapping the given real value.
+    fn spy_from(real: T) -> Self;
+}
+
+/// Conversion trait for turning a real value into a spy.
+///
+/// This is the reciprocal of [`SpyFrom`].  It is automatically available
+/// for any type `T` when a spy struct implements `SpyFrom<T>` (which the
+/// [`spy!`] macro and [`#[autospy]`](attr.autospy.html) generate).
+///
+/// # Examples
+///
+/// ```
+/// use mockall::IntoSpy;
+/// # use mockall::spy;
+/// trait MyTrait { fn foo(&self) -> u32; }
+/// struct Real;
+/// impl MyTrait for Real { fn foo(&self) -> u32 { 42 } }
+/// spy! { Baz {} impl MyTrait for Baz { fn foo(&self) -> u32; } }
+///
+/// # fn main() {
+/// let real = Real;
+/// let spy: SpyBaz<_> = real.into_spy();
+/// assert_eq!(spy.foo(), 42);
+/// # }
+/// ```
+pub trait IntoSpy<S> {
+    /// Convert this object into a spy that wraps it.
+    fn into_spy(self) -> S;
+}
+
+impl<T, S: SpyFrom<T>> IntoSpy<S> for T {
+    fn into_spy(self) -> S {
+        S::spy_from(self)
+    }
+}
 
 #[doc(hidden)]
 pub trait AnyExpectations : Any + Send + Sync {}

--- a/mockall/src/lib.rs
+++ b/mockall/src/lib.rs
@@ -24,6 +24,11 @@
 //!   the preprogrammed return values supplied in the previous step.  Any
 //!   accesses contrary to your expectations will cause a panic.
 //!
+//! Mockall also supports *spies*.  A spy wraps a real implementation and
+//! delegates calls to it by default, but allows individual methods to be
+//! overridden.  Use [`#[autospy]`](attr.autospy.html) or [`spy!`] to
+//! create them.
+//!
 //! # User Guide
 //!
 //! * [`Getting started`](#getting-started)
@@ -46,6 +51,7 @@
 //! * [`Foreign functions`](#foreign-functions)
 //! * [`Debug`](#debug)
 //! * [`Async Traits`](#async-traits)
+//! * [`Spying`](#spying)
 //! * [`Crate features`](#crate-features)
 //! * [`Examples`](#examples)
 //!
@@ -1099,6 +1105,79 @@
 //! # fn main() {}
 //! ```
 //!
+//! ## Spying
+//!
+//! A spy wraps a real implementation and delegates method calls to it by
+//! default, while allowing individual methods to be overridden with
+//! expectations.  This is useful for partial mocking and call verification.
+//!
+//! The easiest way to create a spy is [`#[autospy]`](attr.autospy.html),
+//! which works on traits and struct impls:
+//!
+//! ```
+//! # use mockall::*;
+//! #[autospy]
+//! trait Foo {
+//!     fn foo(&self, x: u32) -> u32;
+//! }
+//!
+//! struct RealFoo;
+//! impl Foo for RealFoo {
+//!     fn foo(&self, x: u32) -> u32 { x * 2 }
+//! }
+//!
+//! # fn main() {
+//! use mockall::predicate::*;
+//!
+//! let mut spy = SpyFoo::new(RealFoo);
+//! assert_eq!(spy.foo(21), 42);     // delegates to real
+//!
+//! spy.expect_foo()
+//!     .times(1)
+//!     .returning(|x| x + 1);
+//! assert_eq!(spy.foo(5), 6);       // overridden
+//! spy.checkpoint();
+//!
+//! // Verify a call with specific arguments using calling_real()
+//! spy.expect_foo()
+//!     .with(eq(10))
+//!     .times(1)
+//!     .calling_real();
+//! assert_eq!(spy.foo(10), 20);     // delegates and verifies
+//! # }
+//! ```
+//!
+//! To spy on async methods, use `#[async_trait]`.  Native `async fn`
+//! and methods returning `impl Future` cannot be spied on directly.
+//!
+//! ```
+//! # use mockall::*;
+//! use async_trait::async_trait;
+//! use futures::executor::block_on;
+//!
+//! #[autospy]
+//! #[async_trait]
+//! trait AsyncFoo: Send + Sync {
+//!     async fn fetch(&self, id: u32) -> String;
+//! }
+//!
+//! struct RealService;
+//! #[async_trait]
+//! impl AsyncFoo for RealService {
+//!     async fn fetch(&self, id: u32) -> String {
+//!         format!("item-{id}")
+//!     }
+//! }
+//!
+//! # fn main() {
+//! let spy = SpyAsyncFoo::new(RealService);
+//! assert_eq!(block_on(spy.fetch(42)), "item-42");
+//! # }
+//! ```
+//!
+//! For more complex cases, there is [`spy!`].  See the [`spy!`] and
+//! [`#[autospy]`](attr.autospy.html) documentation for full details.
+//!
 //! ## Crate features
 //!
 //! Mockall has a **nightly** feature.  Currently this feature has two
@@ -1441,6 +1520,249 @@ pub use mockall_derive::concretize;
 /// # fn main() {}
 /// ```
 pub use mockall_derive::mock;
+
+/// Create a spy struct that wraps a real implementation.
+///
+/// A spy delegates method calls to the real implementation by default, but
+/// allows you to override specific methods with expectations.  This enables
+/// partial mocking and call verification.
+///
+/// Only trait methods can be spied on with `spy!`; inherent methods are not
+/// supported.  Use [`#[autospy]`](attr.autospy.html) on a struct impl block
+/// to spy on inherent methods.
+///
+/// # Examples
+///
+/// ```
+/// # use mockall_derive::spy;
+/// trait MyTrait {
+///     fn method(&self, x: u32) -> u32;
+/// }
+///
+/// struct RealImpl;
+/// impl MyTrait for RealImpl {
+///     fn method(&self, x: u32) -> u32 { x * 2 }
+/// }
+///
+/// spy! {
+///     Foo {
+///     }
+///     impl MyTrait for Foo {
+///         fn method(&self, x: u32) -> u32;
+///     }
+/// }
+///
+/// # fn main() {
+/// let real = RealImpl;
+/// let mut spy = SpyFoo::new(real);
+///
+/// // By default, delegates to the real implementation.
+/// assert_eq!(spy.method(21), 42);
+///
+/// // Override with an expectation.
+/// spy.expect_method()
+///     .returning(|x| x + 1);
+/// assert_eq!(spy.method(5), 6);
+/// # }
+/// ```
+///
+/// Use `calling_real()` to delegate to the real implementation while still
+/// verifying call counts:
+///
+/// ```
+/// # use mockall_derive::spy;
+/// trait Compute {
+///     fn compute(&self, x: u32) -> u32;
+/// }
+///
+/// struct Doubler;
+/// impl Compute for Doubler {
+///     fn compute(&self, x: u32) -> u32 { x * 2 }
+/// }
+///
+/// spy! {
+///     Calc {
+///     }
+///     impl Compute for Calc {
+///         fn compute(&self, x: u32) -> u32;
+///     }
+/// }
+///
+/// # fn main() {
+/// let mut spy = SpyCalc::new(Doubler);
+/// spy.expect_compute()
+///     .times(1)
+///     .calling_real();
+/// assert_eq!(spy.compute(5), 10);
+/// # }
+/// ```
+///
+/// The generated struct is generic: `SpyFoo<T>` where `T` must implement all
+/// the declared traits.  This allows wrapping different concrete types with
+/// the same spy definition.
+///
+/// The `spy!` macro also implements [`IntoSpy`] for any type satisfying the
+/// trait bounds, allowing you to write `real.into_spy()` instead of
+/// `SpyFoo::new(real)`:
+///
+/// ```
+/// # use mockall_derive::spy;
+/// use mockall::IntoSpy;
+///
+/// trait MyTrait { fn method(&self, x: u32) -> u32; }
+/// struct RealImpl;
+/// impl MyTrait for RealImpl { fn method(&self, x: u32) -> u32 { x * 2 } }
+/// spy! { Foo {} impl MyTrait for Foo { fn method(&self, x: u32) -> u32; } }
+///
+/// # fn main() {
+/// let real = RealImpl;
+/// let spy: SpyFoo<_> = real.into_spy();
+/// assert_eq!(spy.method(21), 42);
+/// # }
+/// ```
+///
+/// ## Limitations
+///
+/// * Only trait methods can be spied on.  Use
+///   [`#[autospy]`](attr.autospy.html) for inherent methods.
+/// * Static methods do not delegate; they behave like regular mock
+///   expectations.
+/// * Methods returning `impl Trait` (e.g. `impl Future`) cannot be
+///   spied on.  Use `#[async_trait]` for async methods instead.
+pub use mockall_derive::spy;
+
+/// Automatically generate spy types for traits and struct impls.
+///
+/// Similar to [`#[automock]`](attr.automock.html), but generates a spy struct
+/// (prefixed with "Spy") instead of a mock struct.  A spy delegates method
+/// calls to a wrapped real implementation by default, while allowing individual
+/// methods to be overridden with expectations.
+///
+/// # Examples
+///
+/// ## On a trait
+/// ```
+/// # use mockall::*;
+/// #[autospy]
+/// trait MyTrait {
+///     fn method(&self, x: u32) -> u32;
+/// }
+///
+/// struct RealImpl;
+/// impl MyTrait for RealImpl {
+///     fn method(&self, x: u32) -> u32 { x * 2 }
+/// }
+///
+/// # fn main() {
+/// let real = RealImpl;
+/// let spy = SpyMyTrait::new(real);
+/// assert_eq!(spy.method(21), 42);
+/// # }
+/// ```
+///
+/// ## On a struct impl
+/// ```
+/// # use mockall::*;
+/// struct Foo;
+///
+/// #[autospy]
+/// impl Foo {
+///     fn double(&self, x: u32) -> u32 { x * 2 }
+/// }
+///
+/// # fn main() {
+/// let spy = SpyFoo::new(Foo);
+/// assert_eq!(spy.double(21), 42);
+/// # }
+/// ```
+///
+/// ## With async_trait
+///
+/// To spy on async methods, combine `#[autospy]` with `#[async_trait]`.
+/// The `#[async_trait]` attribute must come after `#[autospy]`.
+///
+/// ```
+/// # use mockall::*;
+/// use async_trait::async_trait;
+/// use futures::executor::block_on;
+///
+/// #[autospy]
+/// #[async_trait]
+/// trait AsyncFoo: Send + Sync {
+///     async fn fetch(&self, id: u32) -> String;
+/// }
+///
+/// struct RealService;
+/// #[async_trait]
+/// impl AsyncFoo for RealService {
+///     async fn fetch(&self, id: u32) -> String {
+///         format!("item-{id}")
+///     }
+/// }
+///
+/// # fn main() {
+/// let mut spy = SpyAsyncFoo::new(RealService);
+/// assert_eq!(block_on(spy.fetch(1)), "item-1");
+///
+/// spy.expect_fetch()
+///     .returning(|_| "mocked".to_string());
+/// assert_eq!(block_on(spy.fetch(99)), "mocked");
+/// # }
+/// ```
+///
+/// ## Limitations
+///
+/// * `#[autospy]` does not support modules.  For module-level mocking,
+///   use [`mock!`] instead.
+/// * Static methods do not delegate; they behave like regular mock
+///   expectations.
+/// * Methods returning `impl Trait` (e.g. `impl Future`) cannot be
+///   spied on.  Use `#[async_trait]` for async methods instead.
+pub use mockall_derive::autospy;
+
+/// Constructor trait for building a spy from a real value.
+///
+/// This trait is automatically implemented by the [`spy!`] macro and
+/// [`#[autospy]`](attr.autospy.html) on the generated spy struct.  You
+/// normally won't call this directly — use the [`IntoSpy`] trait
+/// instead.
+pub trait SpyFrom<T> {
+    /// Create a spy wrapping the given real value.
+    fn spy_from(real: T) -> Self;
+}
+
+/// Conversion trait for turning a real value into a spy.
+///
+/// This is the reciprocal of [`SpyFrom`].  It is automatically available
+/// for any type `T` when a spy struct implements `SpyFrom<T>` (which the
+/// [`spy!`] macro and [`#[autospy]`](attr.autospy.html) generate).
+///
+/// # Examples
+///
+/// ```
+/// use mockall::IntoSpy;
+/// # use mockall::spy;
+/// trait MyTrait { fn foo(&self) -> u32; }
+/// struct Real;
+/// impl MyTrait for Real { fn foo(&self) -> u32 { 42 } }
+/// spy! { Baz {} impl MyTrait for Baz { fn foo(&self) -> u32; } }
+///
+/// # fn main() {
+/// let real = Real;
+/// let spy: SpyBaz<_> = real.into_spy();
+/// assert_eq!(spy.foo(), 42);
+/// # }
+/// ```
+pub trait IntoSpy<S> {
+    /// Convert this object into a spy that wraps it.
+    fn into_spy(self) -> S;
+}
+
+impl<T, S: SpyFrom<T>> IntoSpy<S> for T {
+    fn into_spy(self) -> S {
+        S::spy_from(self)
+    }
+}
 
 #[doc(hidden)]
 pub trait AnyExpectations : Any + Send + Sync {}

--- a/mockall/tests/autospy_basic.rs
+++ b/mockall/tests/autospy_basic.rs
@@ -1,0 +1,53 @@
+// vim: tw=80
+//! Basic autospy tests: delegation, partial mock, IntoSpy
+#![deny(warnings)]
+
+use mockall::*;
+
+#[autospy]
+trait MyTrait {
+    fn method(&self, x: u32) -> u32;
+    fn other(&mut self, s: &str) -> bool;
+}
+
+struct RealFoo;
+
+impl MyTrait for RealFoo {
+    fn method(&self, x: u32) -> u32 {
+        x * 2
+    }
+    fn other(&mut self, _s: &str) -> bool {
+        false
+    }
+}
+
+#[test]
+fn delegates_to_real_by_default() {
+    let real = RealFoo;
+    let spy = SpyMyTrait::new(real);
+    assert_eq!(spy.method(21), 42);
+}
+
+#[test]
+fn override_with_expectation() {
+    let real = RealFoo;
+    let mut spy = SpyMyTrait::new(real);
+    spy.expect_method()
+        .returning(|x| x + 1);
+    assert_eq!(spy.method(5), 6);
+}
+
+#[test]
+fn mut_method_delegates() {
+    let real = RealFoo;
+    let mut spy = SpyMyTrait::new(real);
+    assert!(!spy.other("hello"));
+}
+
+#[test]
+fn into_spy_works() {
+    use mockall::IntoSpy;
+    let real = RealFoo;
+    let spy: SpyMyTrait<_> = real.into_spy();
+    assert_eq!(spy.method(10), 20);
+}

--- a/mockall/tests/autospy_struct.rs
+++ b/mockall/tests/autospy_struct.rs
@@ -1,0 +1,49 @@
+// vim: tw=80
+//! Tests for #[autospy] on struct impl blocks (inherent methods)
+#![deny(warnings)]
+
+use mockall::*;
+
+struct Foo;
+
+#[autospy]
+impl Foo {
+    fn double(&self, x: u32) -> u32 {
+        x * 2
+    }
+    fn is_empty(&self, s: &str) -> bool {
+        s.is_empty()
+    }
+}
+
+#[test]
+fn delegates_to_real_by_default() {
+    let real = Foo;
+    let spy = SpyFoo::new(real);
+    assert_eq!(spy.double(21), 42);
+}
+
+#[test]
+fn override_with_expectation() {
+    let real = Foo;
+    let mut spy = SpyFoo::new(real);
+    spy.expect_double()
+        .returning(|x| x + 1);
+    assert_eq!(spy.double(5), 6);
+}
+
+#[test]
+fn second_method_delegates() {
+    let real = Foo;
+    let spy = SpyFoo::new(real);
+    assert!(spy.is_empty(""));
+    assert!(!spy.is_empty("hello"));
+}
+
+#[test]
+fn into_spy_works() {
+    use mockall::IntoSpy;
+    let real = Foo;
+    let spy: SpyFoo = real.into_spy();
+    assert_eq!(spy.double(10), 20);
+}

--- a/mockall/tests/spy_async.rs
+++ b/mockall/tests/spy_async.rs
@@ -1,0 +1,140 @@
+// vim: tw=80
+//! Async method spy tests: spy! and #[autospy] with async_trait
+#![deny(warnings)]
+
+use async_trait::async_trait;
+use futures::executor::block_on;
+use mockall::*;
+
+// ── spy! with async_trait ───────────────────────────────────────────
+
+#[async_trait]
+trait AsyncCalc: Send + Sync {
+    async fn compute(&self, x: u32) -> u32;
+    async fn greet(&self, name: &str) -> String;
+}
+
+struct RealCalc;
+
+#[async_trait]
+impl AsyncCalc for RealCalc {
+    async fn compute(&self, x: u32) -> u32 {
+        x * 3
+    }
+    async fn greet(&self, name: &str) -> String {
+        format!("hello {name}")
+    }
+}
+
+spy! {
+    Calc {}
+    #[async_trait]
+    impl AsyncCalc for Calc {
+        async fn compute(&self, x: u32) -> u32;
+        async fn greet(&self, name: &str) -> String;
+    }
+}
+
+mod spy_macro {
+    use super::*;
+
+    #[test]
+    fn delegates_async_method() {
+        let spy = SpyCalc::new(RealCalc);
+        assert_eq!(block_on(spy.compute(7)), 21);
+    }
+
+    #[test]
+    fn delegates_async_method_returning_string() {
+        let spy = SpyCalc::new(RealCalc);
+        assert_eq!(block_on(spy.greet("world")), "hello world");
+    }
+
+    #[test]
+    fn override_async_method() {
+        let mut spy = SpyCalc::new(RealCalc);
+        spy.expect_compute()
+            .returning(|x| x + 100);
+        assert_eq!(block_on(spy.compute(5)), 105);
+    }
+
+    #[test]
+    fn calling_real_async() {
+        let mut spy = SpyCalc::new(RealCalc);
+        spy.expect_compute()
+            .times(1)
+            .calling_real();
+        assert_eq!(block_on(spy.compute(10)), 30);
+    }
+
+    #[test]
+    fn partial_mock_async() {
+        let mut spy = SpyCalc::new(RealCalc);
+        spy.expect_compute()
+            .returning(|_| 999);
+        // overridden
+        assert_eq!(block_on(spy.compute(1)), 999);
+        // non-overridden still delegates
+        assert_eq!(block_on(spy.greet("rust")), "hello rust");
+    }
+}
+
+// ── #[autospy] with async_trait ─────────────────────────────────────
+
+#[autospy]
+#[async_trait]
+trait AsyncStore: Send + Sync {
+    async fn get(&self, key: &str) -> Option<String>;
+    async fn put(&mut self, key: &str, value: &str) -> bool;
+}
+
+struct MemStore;
+
+#[async_trait]
+impl AsyncStore for MemStore {
+    async fn get(&self, _key: &str) -> Option<String> {
+        Some("stored".to_string())
+    }
+    async fn put(&mut self, _key: &str, _value: &str) -> bool {
+        true
+    }
+}
+
+mod autospy_attr {
+    use super::*;
+
+    #[test]
+    fn delegates_async_get() {
+        let spy = SpyAsyncStore::new(MemStore);
+        assert_eq!(
+            block_on(spy.get("k")),
+            Some("stored".to_string())
+        );
+    }
+
+    #[test]
+    fn delegates_async_put() {
+        let mut spy = SpyAsyncStore::new(MemStore);
+        assert!(block_on(spy.put("k", "v")));
+    }
+
+    #[test]
+    fn override_async_get() {
+        let mut spy = SpyAsyncStore::new(MemStore);
+        spy.expect_get()
+            .returning(|_| None);
+        assert_eq!(block_on(spy.get("k")), None);
+    }
+
+    #[test]
+    fn calling_real_async() {
+        let mut spy = SpyAsyncStore::new(MemStore);
+        spy.expect_get()
+            .times(1)
+            .calling_real();
+        assert_eq!(
+            block_on(spy.get("k")),
+            Some("stored".to_string())
+        );
+    }
+}

--- a/mockall/tests/spy_basic.rs
+++ b/mockall/tests/spy_basic.rs
@@ -1,0 +1,116 @@
+// vim: tw=80
+//! Basic spy tests: delegation, partial mock, calling_real(), checkpoint
+#![deny(warnings)]
+
+use mockall::*;
+
+struct RealFoo;
+
+trait MyTrait {
+    fn method(&self, x: u32) -> u32;
+    fn other(&mut self, s: &str) -> bool;
+}
+
+impl MyTrait for RealFoo {
+    fn method(&self, x: u32) -> u32 {
+        x * 2
+    }
+    fn other(&mut self, _s: &str) -> bool {
+        false
+    }
+}
+
+spy! {
+    Foo {
+    }
+    impl MyTrait for Foo {
+        fn method(&self, x: u32) -> u32;
+        fn other(&mut self, s: &str) -> bool;
+    }
+}
+
+mod delegation {
+    use super::*;
+
+    #[test]
+    fn delegates_to_real_by_default() {
+        let real = RealFoo;
+        let spy = SpyFoo::new(real);
+        assert_eq!(spy.method(21), 42);
+    }
+
+    #[test]
+    fn delegates_mut_method() {
+        let real = RealFoo;
+        let mut spy = SpyFoo::new(real);
+        assert!(!spy.other("test"));
+    }
+}
+
+mod partial_mock {
+    use super::*;
+
+    #[test]
+    fn override_one_method() {
+        let real = RealFoo;
+        let mut spy = SpyFoo::new(real);
+        spy.expect_other()
+            .returning(|_| true);
+        // overridden method returns mock value
+        assert!(spy.other("test"));
+        // non-overridden method still delegates
+        assert_eq!(spy.method(10), 20);
+    }
+}
+
+mod calling_real {
+    use super::*;
+
+    #[test]
+    fn calling_real_delegates_and_records() {
+        let real = RealFoo;
+        let mut spy = SpyFoo::new(real);
+        spy.expect_method()
+            .times(1)
+            .calling_real();
+        // Should delegate to real AND record the call
+        assert_eq!(spy.method(5), 10);
+    }
+}
+
+mod into_spy {
+    use super::*;
+    use mockall::IntoSpy;
+
+    #[test]
+    fn into_spy_delegates_by_default() {
+        let real = RealFoo;
+        let spy: SpyFoo<_> = real.into_spy();
+        assert_eq!(spy.method(21), 42);
+    }
+
+    #[test]
+    fn into_spy_with_expectation() {
+        let real = RealFoo;
+        let mut spy: SpyFoo<_> = real.into_spy();
+        spy.expect_method()
+            .returning(|x| x + 1);
+        assert_eq!(spy.method(5), 6);
+    }
+}
+
+mod checkpoint {
+    use super::*;
+
+    #[test]
+    fn checkpoint_resets_expectations() {
+        let real = RealFoo;
+        let mut spy = SpyFoo::new(real);
+        spy.expect_method()
+            .returning(|_| 999);
+        assert_eq!(spy.method(1), 999);
+        spy.checkpoint();
+        // After checkpoint, should delegate to real again
+        assert_eq!(spy.method(5), 10);
+    }
+}

--- a/mockall/tests/spy_edge_cases.rs
+++ b/mockall/tests/spy_edge_cases.rs
@@ -1,0 +1,63 @@
+// vim: tw=80
+//! Edge case tests for spy: different impl types with same spy
+#![deny(warnings)]
+
+use mockall::*;
+
+trait Computable {
+    fn compute(&self, x: u32) -> u32;
+}
+
+struct Doubler;
+impl Computable for Doubler {
+    fn compute(&self, x: u32) -> u32 {
+        x * 2
+    }
+}
+
+struct Tripler;
+impl Computable for Tripler {
+    fn compute(&self, x: u32) -> u32 {
+        x * 3
+    }
+}
+
+spy! {
+    Calc {
+    }
+    impl Computable for Calc {
+        fn compute(&self, x: u32) -> u32;
+    }
+}
+
+#[test]
+fn into_spy_with_different_impl_types() {
+    use mockall::IntoSpy;
+    let spy_doubler: SpyCalc<_> = Doubler.into_spy();
+    assert_eq!(spy_doubler.compute(5), 10);
+
+    let spy_tripler: SpyCalc<_> = Tripler.into_spy();
+    assert_eq!(spy_tripler.compute(5), 15);
+}
+
+#[test]
+fn different_impl_types_same_spy() {
+    let spy_doubler = SpyCalc::new(Doubler);
+    assert_eq!(spy_doubler.compute(5), 10);
+
+    let spy_tripler = SpyCalc::new(Tripler);
+    assert_eq!(spy_tripler.compute(5), 15);
+}
+
+#[test]
+fn override_with_different_impls() {
+    let mut spy = SpyCalc::new(Doubler);
+    spy.expect_compute()
+        .returning(|x| x + 1);
+    assert_eq!(spy.compute(5), 6);
+
+    let mut spy2 = SpyCalc::new(Tripler);
+    spy2.expect_compute()
+        .returning(|x| x + 1);
+    assert_eq!(spy2.compute(5), 6);
+}

--- a/mockall/tests/spy_multi_trait.rs
+++ b/mockall/tests/spy_multi_trait.rs
@@ -1,0 +1,79 @@
+// vim: tw=80
+//! Tests for spy with multiple trait implementations
+#![deny(warnings)]
+
+use mockall::*;
+
+trait TraitA {
+    fn alpha(&self, x: i32) -> i32;
+}
+
+trait TraitB {
+    fn beta(&self) -> String;
+}
+
+struct RealBar;
+
+impl TraitA for RealBar {
+    fn alpha(&self, x: i32) -> i32 {
+        x + 100
+    }
+}
+
+impl TraitB for RealBar {
+    fn beta(&self) -> String {
+        "real".to_string()
+    }
+}
+
+spy! {
+    Bar {
+    }
+    impl TraitA for Bar {
+        fn alpha(&self, x: i32) -> i32;
+    }
+    impl TraitB for Bar {
+        fn beta(&self) -> String;
+    }
+}
+
+#[test]
+fn delegates_both_traits() {
+    let real = RealBar;
+    let spy = SpyBar::new(real);
+    assert_eq!(spy.alpha(1), 101);
+    assert_eq!(spy.beta(), "real");
+}
+
+#[test]
+fn override_one_trait_delegate_other() {
+    let real = RealBar;
+    let mut spy = SpyBar::new(real);
+    spy.expect_beta()
+        .returning(|| "mocked".to_string());
+    // TraitB overridden
+    assert_eq!(spy.beta(), "mocked");
+    // TraitA still delegates
+    assert_eq!(spy.alpha(5), 105);
+}
+
+#[test]
+fn into_spy_delegates_both_traits() {
+    use mockall::IntoSpy;
+    let real = RealBar;
+    let spy: SpyBar<_> = real.into_spy();
+    assert_eq!(spy.alpha(1), 101);
+    assert_eq!(spy.beta(), "real");
+}
+
+#[test]
+fn override_both_traits() {
+    let real = RealBar;
+    let mut spy = SpyBar::new(real);
+    spy.expect_alpha()
+        .returning(|_| -1);
+    spy.expect_beta()
+        .returning(|| "fake".to_string());
+    assert_eq!(spy.alpha(42), -1);
+    assert_eq!(spy.beta(), "fake");
+}

--- a/mockall_derive/src/lib.rs
+++ b/mockall_derive/src/lib.rs
@@ -1064,9 +1064,21 @@ fn gen_keyid(g: &Generics) -> impl ToTokens {
     }
 }
 
+/// Controls what kind of struct is generated.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum GenerateMode {
+    Mock,
+    Spy,
+}
+
 /// Generate a mock identifier from the regular one: eg "Foo" => "MockFoo"
 fn gen_mock_ident(ident: &Ident) -> Ident {
     format_ident!("Mock{}", ident)
+}
+
+/// Generate a spy identifier from the regular one: eg "Foo" => "SpyFoo"
+fn gen_spy_ident(ident: &Ident) -> Ident {
+    format_ident!("Spy{}", ident)
 }
 
 /// Generate an identifier for the mock struct's private module: eg "Foo" =>
@@ -1352,6 +1364,74 @@ fn do_mock(input: TokenStream) -> TokenStream
         }
     }
     do_mock_once(input)
+}
+
+fn do_spy_once(input: TokenStream) -> TokenStream
+{
+    let item: MockableStruct = match syn::parse::Parser::parse2(
+        MockableStruct::parse_spy, input)
+    {
+        Ok(mock) => mock,
+        Err(err) => {
+            return err.to_compile_error();
+        }
+    };
+    mock_it(item)
+}
+
+fn do_spy(input: TokenStream) -> TokenStream
+{
+    cfg_if! {
+        if #[cfg(reprocheck)] {
+            let ts_a = do_spy_once(input.clone());
+            let ts_b = do_spy_once(input.clone());
+            assert_eq!(ts_a.to_string(), ts_b.to_string());
+        }
+    }
+    do_spy_once(input)
+}
+
+#[proc_macro]
+pub fn spy(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    do_spy(input.into()).into()
+}
+
+#[proc_macro_attribute]
+pub fn autospy(attrs: proc_macro::TokenStream, input: proc_macro::TokenStream)
+    -> proc_macro::TokenStream
+{
+    let attrs: proc_macro2::TokenStream = attrs.into();
+    let input: proc_macro2::TokenStream = input.into();
+    do_autospy(attrs, input).into()
+}
+
+fn do_autospy_once(attrs: TokenStream, input: TokenStream) -> TokenStream {
+    let mut output = input.clone();
+    let attrs: Attrs = match parse2(attrs) {
+        Ok(a) => a,
+        Err(err) => {
+            return err.to_compile_error();
+        }
+    };
+    let item: Item = match parse2(input) {
+        Ok(item) => item,
+        Err(err) => {
+            return err.to_compile_error();
+        }
+    };
+    output.extend(mock_it(MockableItem::from_autospy(attrs, item)));
+    output
+}
+
+fn do_autospy(attrs: TokenStream, input: TokenStream) -> TokenStream {
+    cfg_if! {
+        if #[cfg(reprocheck)] {
+            let ts_a = do_autospy_once(attrs.clone(), input.clone());
+            let ts_b = do_autospy_once(attrs.clone(), input.clone());
+            assert_eq!(ts_a.to_string(), ts_b.to_string());
+        }
+    }
+    do_autospy_once(attrs, input)
 }
 
 #[proc_macro_attribute]

--- a/mockall_derive/src/lib.rs
+++ b/mockall_derive/src/lib.rs
@@ -1068,9 +1068,21 @@ fn gen_keyid(g: &Generics) -> impl ToTokens {
     }
 }
 
+/// Controls what kind of struct is generated.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum GenerateMode {
+    Mock,
+    Spy,
+}
+
 /// Generate a mock identifier from the regular one: eg "Foo" => "MockFoo"
 fn gen_mock_ident(ident: &Ident) -> Ident {
     format_ident!("Mock{}", ident)
+}
+
+/// Generate a spy identifier from the regular one: eg "Foo" => "SpyFoo"
+fn gen_spy_ident(ident: &Ident) -> Ident {
+    format_ident!("Spy{}", ident)
 }
 
 /// Generate an identifier for the mock struct's private module: eg "Foo" =>
@@ -1356,6 +1368,74 @@ fn do_mock(input: TokenStream) -> TokenStream
         }
     }
     do_mock_once(input)
+}
+
+fn do_spy_once(input: TokenStream) -> TokenStream
+{
+    let item: MockableStruct = match syn::parse::Parser::parse2(
+        MockableStruct::parse_spy, input)
+    {
+        Ok(mock) => mock,
+        Err(err) => {
+            return err.to_compile_error();
+        }
+    };
+    mock_it(item)
+}
+
+fn do_spy(input: TokenStream) -> TokenStream
+{
+    cfg_if! {
+        if #[cfg(reprocheck)] {
+            let ts_a = do_spy_once(input.clone());
+            let ts_b = do_spy_once(input.clone());
+            assert_eq!(ts_a.to_string(), ts_b.to_string());
+        }
+    }
+    do_spy_once(input)
+}
+
+#[proc_macro]
+pub fn spy(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    do_spy(input.into()).into()
+}
+
+#[proc_macro_attribute]
+pub fn autospy(attrs: proc_macro::TokenStream, input: proc_macro::TokenStream)
+    -> proc_macro::TokenStream
+{
+    let attrs: proc_macro2::TokenStream = attrs.into();
+    let input: proc_macro2::TokenStream = input.into();
+    do_autospy(attrs, input).into()
+}
+
+fn do_autospy_once(attrs: TokenStream, input: TokenStream) -> TokenStream {
+    let mut output = input.clone();
+    let attrs: Attrs = match parse2(attrs) {
+        Ok(a) => a,
+        Err(err) => {
+            return err.to_compile_error();
+        }
+    };
+    let item: Item = match parse2(input) {
+        Ok(item) => item,
+        Err(err) => {
+            return err.to_compile_error();
+        }
+    };
+    output.extend(mock_it(MockableItem::from_autospy(attrs, item)));
+    output
+}
+
+fn do_autospy(attrs: TokenStream, input: TokenStream) -> TokenStream {
+    cfg_if! {
+        if #[cfg(reprocheck)] {
+            let ts_a = do_autospy_once(attrs.clone(), input.clone());
+            let ts_b = do_autospy_once(attrs.clone(), input.clone());
+            assert_eq!(ts_a.to_string(), ts_b.to_string());
+        }
+    }
+    do_autospy_once(attrs, input)
 }
 
 #[proc_macro_attribute]

--- a/mockall_derive/src/mock_function.rs
+++ b/mockall_derive/src/mock_function.rs
@@ -10,6 +10,7 @@ use syn::{
 
 use crate::{
     AttrFormatter,
+    GenerateMode,
     HashSet,
     compile_error,
     concretize_args,
@@ -193,6 +194,7 @@ pub(crate) struct Builder<'a> {
     levels: usize,
     parent: Option<&'a Ident>,
     sig: &'a Signature,
+    generate_mode: GenerateMode,
     struct_: Option<&'a Ident>,
     struct_generics: Option<&'a Generics>,
     trait_: Option<&'a Ident>,
@@ -348,6 +350,7 @@ impl<'a> Builder<'a> {
             return_ref,
             return_refmut,
             sig,
+            generate_mode: self.generate_mode,
             struct_: self.struct_.cloned(),
             struct_generics,
             trait_: self.trait_.cloned(),
@@ -382,11 +385,18 @@ impl<'a> Builder<'a> {
             call_levels: None,
             parent: None,
             sig,
+            generate_mode: GenerateMode::Mock,
             struct_: None,
             struct_generics: None,
             trait_: None,
             vis
         }
+    }
+
+    /// Set the generation mode for this function
+    pub fn generate_mode(&mut self, generate_mode: GenerateMode) -> &mut Self {
+        self.generate_mode = generate_mode;
+        self
     }
 
     /// Supply the name of the parent module
@@ -469,6 +479,8 @@ pub(crate) struct MockFunction {
     struct_: Option<Ident>,
     /// Generics of the parent structure
     struct_generics: Generics,
+    /// What kind of struct to generate
+    generate_mode: GenerateMode,
     /// Name of this method's trait, if the method comes from a trait
     trait_: Option<Ident>,
     /// Type generics of the mock structure
@@ -570,6 +582,34 @@ impl MockFunction {
                                 .map(|mut g| g.checkpoint().collect::<Vec<_>>());
                             ::std::panic::resume_unwind(__mockall_e);
                         })
+                    }
+                }
+            )
+        } else if self.generate_mode == GenerateMode::Spy {
+            let method_ident = self.name();
+            let argnames = &self.argnames;
+            let spy_call = if self.return_refmut {
+                Ident::new("spy_call_mut", Span::call_site())
+            } else {
+                Ident::new("spy_call", Span::call_site())
+            };
+            let await_token = if self.sig.asyncness.is_some() {
+                quote!(.await)
+            } else {
+                quote!()
+            };
+            quote!(
+                #(#attrs)*
+                #dead_code
+                #no_mangle
+                #vis #sig {
+                    if let Some(__mockall_result) =
+                        self.#substruct_obj #name.#spy_call #tbf(#(#call_exprs,)*)
+                    {
+                        #deref __mockall_result
+                    } else {
+                        self.__mockall_real.#method_ident(#(#argnames,)*)
+                            #await_token
                     }
                 }
             )
@@ -955,7 +995,8 @@ impl ToTokens for Common<'_> {
             struct Common #ig #wc {
                 matcher: Mutex<Matcher #tg>,
                 seq_handle: Option<::mockall::SeqHandle>,
-                times: ::mockall::Times
+                times: ::mockall::Times,
+                call_real: bool,
             }
 
             impl #ig std::default::Default for Common #tg #wc
@@ -964,7 +1005,8 @@ impl ToTokens for Common<'_> {
                     Common {
                         matcher: Mutex::new(Matcher::default()),
                         seq_handle: None,
-                        times: ::mockall::Times::default()
+                        times: ::mockall::Times::default(),
+                        call_real: false,
                     }
                 }
             }
@@ -1221,6 +1263,18 @@ impl ToTokens for CommonExpectationMethods<'_> {
                 self
             }
         ).to_tokens(tokens);
+
+        // Generate calling_real() only in spy mode
+        if self.f.generate_mode == GenerateMode::Spy {
+            quote!(
+                /// Delegate to the real implementation while still
+                /// recording the call for verification.
+                #v fn calling_real(&mut self) -> &mut Self {
+                    self.common.call_real = true;
+                    self
+                }
+            ).to_tokens(tokens);
+        }
     }
 }
 
@@ -2082,6 +2136,30 @@ impl ToTokens for RefExpectation<'_> {
                 }
             }
         ).to_tokens(tokens);
+
+        // Generate spy_call() for spy mode (ref return)
+        if self.f.generate_mode == GenerateMode::Spy {
+            let argnames = &self.f.argnames;
+            let argty = &self.f.argty;
+            let (ig, tg, wc) = self.f.egenerics.split_for_impl();
+            let lg = lifetimes_to_generics(&self.f.alifetimes);
+            let output = &self.f.output;
+            let v = &self.f.privmod_vis;
+            quote!(
+                impl #ig Expectation #tg #wc {
+                    #[doc(hidden)]
+                    #v fn spy_call #lg (&self, #(#argnames: #argty, )* )
+                        -> Option<#output>
+                    {
+                        if self.common.call_real {
+                            panic!("calling_real() is not supported for \
+                                    methods returning references");
+                        }
+                        Some(self.call(#(#argnames, )*))
+                    }
+                }
+            ).to_tokens(tokens);
+        }
     }
 }
 
@@ -2171,6 +2249,30 @@ impl ToTokens for RefMutExpectation<'_> {
                 }
             }
         ).to_tokens(tokens);
+
+        // Generate spy_call_mut() for spy mode (refmut return)
+        if self.f.generate_mode == GenerateMode::Spy {
+            let argnames = &self.f.argnames;
+            let argty = &self.f.argty;
+            let (ig, tg, wc) = self.f.egenerics.split_for_impl();
+            let lg = lifetimes_to_generics(&self.f.alifetimes);
+            let owned_output = &self.f.owned_output;
+            let v = &self.f.privmod_vis;
+            quote!(
+                impl #ig Expectation #tg #wc {
+                    #[doc(hidden)]
+                    #v fn spy_call_mut #lg (&mut self, #(#argnames: #argty, )* )
+                        -> Option<&mut #owned_output>
+                    {
+                        if self.common.call_real {
+                            panic!("calling_real() is not supported for \
+                                    methods returning mutable references");
+                        }
+                        Some(self.call_mut(#(#argnames, )*))
+                    }
+                }
+            ).to_tokens(tokens);
+        }
     }
 }
 
@@ -2346,6 +2448,38 @@ impl ToTokens for StaticExpectation<'_> {
                 }
             }
         ).to_tokens(tokens);
+
+        // Generate spy_call() for spy mode
+        if self.f.generate_mode == GenerateMode::Spy {
+            let argnames = &self.f.argnames;
+            let argty = &self.f.argty;
+            let (desc_fmt, desc_args) = self.f.desc();
+            let (ig, tg, wc) = self.f.egenerics.split_for_impl();
+            let lg = lifetimes_to_generics(&self.f.alifetimes);
+            let output = &self.f.output;
+            let v = &self.f.privmod_vis;
+            quote!(
+                #[allow(clippy::unused_unit)]
+                impl #ig Expectation #tg #wc {
+                    /// Call this Expectation in spy mode.
+                    /// Returns Some(value) if the expectation provides a value,
+                    /// or None if the real implementation should be called.
+                    #[doc(hidden)]
+                    #v fn spy_call #lg (&self, #(#argnames: #argty, )* )
+                        -> Option<#output>
+                    {
+                        if self.common.call_real {
+                            use ::mockall::{ViaDebug, ViaNothing};
+                            self.common.call(
+                                || std::format!(#desc_fmt, #desc_args));
+                            None
+                        } else {
+                            Some(self.call(#(#argnames, )*))
+                        }
+                    }
+                }
+            ).to_tokens(tokens);
+        }
     }
 }
 
@@ -2387,6 +2521,36 @@ impl ToTokens for RefExpectations<'_> {
 
             }
         ).to_tokens(tokens);
+
+        // Generate spy_call() for spy mode
+        if self.f.generate_mode == GenerateMode::Spy {
+            let argnames = &self.f.argnames;
+            let argty = &self.f.argty;
+            let (ig, tg, wc) = self.f.egenerics.split_for_impl();
+            let lg = lifetimes_to_generics(&self.f.alifetimes);
+            let output = &self.f.output;
+            let predexprs = &self.f.predexprs;
+            let v = &self.f.privmod_vis;
+            quote!(
+                impl #ig Expectations #tg #wc {
+                    #v fn spy_call #lg (&self, #(#argnames: #argty, )* )
+                        -> Option<#output>
+                    {
+                        use ::mockall::{ViaDebug, ViaNothing};
+                        let __mockall_e = self.0.iter()
+                            .find(|__mockall_e|
+                                  __mockall_e.matches(#(#predexprs, )*) &&
+                                  (!__mockall_e.is_done()
+                                   || self.0.len() == 1));
+                        match __mockall_e {
+                            Some(__mockall_e) =>
+                                __mockall_e.spy_call(#(#argnames, )*),
+                            None => None,
+                        }
+                    }
+                }
+            ).to_tokens(tokens);
+        }
     }
 }
 
@@ -2429,6 +2593,37 @@ impl ToTokens for RefMutExpectations<'_> {
 
             }
         ).to_tokens(tokens);
+
+        // Generate spy_call_mut() for spy mode
+        if self.f.generate_mode == GenerateMode::Spy {
+            let argnames = &self.f.argnames;
+            let argty = &self.f.argty;
+            let (ig, tg, wc) = self.f.egenerics.split_for_impl();
+            let lg = lifetimes_to_generics(&self.f.alifetimes);
+            let owned_output = &self.f.owned_output;
+            let predexprs = &self.f.predexprs;
+            let v = &self.f.privmod_vis;
+            quote!(
+                impl #ig Expectations #tg #wc {
+                    #v fn spy_call_mut #lg (&mut self, #(#argnames: #argty, )* )
+                        -> Option<&mut #owned_output>
+                    {
+                        use ::mockall::{ViaDebug, ViaNothing};
+                        let __mockall_n = self.0.len();
+                        let __mockall_e = self.0.iter_mut()
+                            .find(|__mockall_e|
+                                  __mockall_e.matches(#(#predexprs, )*) &&
+                                  (!__mockall_e.is_done()
+                                   || __mockall_n == 1));
+                        match __mockall_e {
+                            Some(__mockall_e) =>
+                                __mockall_e.spy_call_mut(#(#argnames, )*),
+                            None => None,
+                        }
+                    }
+                }
+            ).to_tokens(tokens);
+        }
     }
 }
 
@@ -2470,6 +2665,36 @@ impl ToTokens for StaticExpectations<'_> {
 
             }
         ).to_tokens(tokens);
+
+        // Generate spy_call() for spy mode
+        if self.f.generate_mode == GenerateMode::Spy {
+            let argnames = &self.f.argnames;
+            let argty = &self.f.argty;
+            let (ig, tg, wc) = self.f.egenerics.split_for_impl();
+            let lg = lifetimes_to_generics(&self.f.alifetimes);
+            let output = &self.f.output;
+            let predexprs = &self.f.predexprs;
+            let v = &self.f.privmod_vis;
+            quote!(
+                impl #ig Expectations #tg #wc {
+                    #v fn spy_call #lg (&self, #(#argnames: #argty, )* )
+                        -> Option<#output>
+                    {
+                        use ::mockall::{ViaDebug, ViaNothing};
+                        let __mockall_e = self.0.iter()
+                            .find(|__mockall_e|
+                                  __mockall_e.matches(#(#predexprs, )*) &&
+                                  (!__mockall_e.is_done()
+                                   || self.0.len() == 1));
+                        match __mockall_e {
+                            Some(__mockall_e) =>
+                                __mockall_e.spy_call(#(#argnames, )*),
+                            None => None,
+                        }
+                    }
+                }
+            ).to_tokens(tokens);
+        }
     }
 }
 

--- a/mockall_derive/src/mock_item.rs
+++ b/mockall_derive/src/mock_item.rs
@@ -16,14 +16,14 @@ use crate::{
 /// A Mock item
 pub(crate) enum MockItem {
     Module(MockItemModule),
-    Struct(MockItemStruct)
+    Struct(Box<MockItemStruct>)
 }
 
 impl From<MockableItem> for MockItem {
     fn from(mockable: MockableItem) -> MockItem {
         match mockable {
             MockableItem::Struct(s) => MockItem::Struct(
-                MockItemStruct::from(s)
+                Box::new(MockItemStruct::from(*s))
             ),
             MockableItem::Module(mod_) => MockItem::Module(
                 MockItemModule::from(mod_)

--- a/mockall_derive/src/mock_item_struct.rs
+++ b/mockall_derive/src/mock_item_struct.rs
@@ -10,6 +10,7 @@ use syn::{
 
 use crate::{
     AttrFormatter,
+    GenerateMode,
     MockableStruct,
     compile_error,
     gen_mod_ident,
@@ -141,6 +142,11 @@ pub(crate) struct MockItemStruct {
     /// Is this a whole MockStruct or just a substructure for a trait impl?
     traits: Vec<MockTrait>,
     vis: Visibility,
+    /// What kind of struct to generate
+    generate_mode: GenerateMode,
+    /// For struct impl spy mode, the concrete type of the wrapped value.
+    /// `None` for trait-based spies (which use `__MockallT`) and all mocks.
+    spy_real_type: Option<Type>,
 }
 
 impl MockItemStruct {
@@ -192,12 +198,107 @@ impl MockItemStruct {
 }
 
 impl From<MockableStruct> for MockItemStruct {
-    fn from(mockable: MockableStruct) -> MockItemStruct {
+    fn from(mut mockable: MockableStruct) -> MockItemStruct {
         let auto_debug = mockable.derives_debug();
         let modname = gen_mod_ident(&mockable.name, None);
-        let generics = mockable.generics.clone();
+        let mut generics = mockable.generics.clone();
         let struct_name = &mockable.name;
         let vis = mockable.vis;
+        let generate_mode = mockable.generate_mode;
+
+        // For trait-based spy mode, add __MockallT generic parameter with
+        // trait bounds.  For struct impl spy mode (spy_real_type is Some),
+        // we use the concrete type instead.
+        if generate_mode == GenerateMode::Spy
+            && mockable.spy_real_type.is_none()
+        {
+            let mut trait_bounds =
+                syn::punctuated::Punctuated::<TypeParamBound, Token![+]>::new();
+            for impl_ in &mockable.impls {
+                if let Some((_, path, _)) = &impl_.trait_ {
+                    trait_bounds.push(TypeParamBound::Trait(TraitBound {
+                        paren_token: None,
+                        modifier: TraitBoundModifier::None,
+                        lifetimes: None,
+                        path: path.clone(),
+                    }));
+                }
+            }
+            let tp = TypeParam {
+                attrs: Vec::new(),
+                ident: format_ident!("__MockallT"),
+                colon_token: Some(Token![:](proc_macro2::Span::call_site())),
+                bounds: trait_bounds.clone(),
+                eq_token: None,
+                default: None,
+            };
+            generics.lt_token
+                .get_or_insert(Token![<](proc_macro2::Span::call_site()));
+            generics.gt_token
+                .get_or_insert(Token![>](proc_macro2::Span::call_site()));
+            generics.params.push(GenericParam::Type(tp));
+
+            // Update each impl block to include __MockallT in self_ty
+            // and in the impl's own generics
+            for impl_ in mockable.impls.iter_mut() {
+                // Add __MockallT generic parameter to impl generics
+                let impl_tp = TypeParam {
+                    attrs: Vec::new(),
+                    ident: format_ident!("__MockallT"),
+                    colon_token: Some(Token![:](
+                        proc_macro2::Span::call_site(),
+                    )),
+                    bounds: trait_bounds.clone(),
+                    eq_token: None,
+                    default: None,
+                };
+                impl_.generics.lt_token.get_or_insert(
+                    Token![<](proc_macro2::Span::call_site()),
+                );
+                impl_.generics.gt_token.get_or_insert(
+                    Token![>](proc_macro2::Span::call_site()),
+                );
+                impl_.generics.params.push(GenericParam::Type(impl_tp));
+
+                // Add <__MockallT> to self_ty path arguments
+                if let Type::Path(ref mut type_path) = *impl_.self_ty {
+                    if let Some(seg) = type_path.path.segments.last_mut() {
+                        let args = &mut seg.arguments;
+                        match args {
+                            PathArguments::None => {
+                                let mockall_t: Type =
+                                    syn::parse_quote!(__MockallT);
+                                *args = PathArguments::AngleBracketed(
+                                    AngleBracketedGenericArguments {
+                                        colon2_token: None,
+                                        lt_token: Token![<](
+                                            proc_macro2::Span::call_site(),
+                                        ),
+                                        args: {
+                                            let mut p = syn::punctuated::Punctuated::new();
+                                            p.push(GenericArgument::Type(
+                                                mockall_t,
+                                            ));
+                                            p
+                                        },
+                                        gt_token: Token![>](
+                                            proc_macro2::Span::call_site(),
+                                        ),
+                                    },
+                                );
+                            }
+                            PathArguments::AngleBracketed(ref mut ab) => {
+                                let mockall_t: Type =
+                                    syn::parse_quote!(__MockallT);
+                                ab.args.push(GenericArgument::Type(mockall_t));
+                            }
+                            _ => {}
+                        }
+                    }
+                }
+            }
+        }
+
         let has_new = mockable.methods.iter()
             .any(|meth| meth.sig.ident == "new") ||
             mockable.impls.iter()
@@ -218,11 +319,12 @@ impl From<MockableStruct> for MockItemStruct {
                     .struct_generics(&generics)
                     .levels(2)
                     .call_levels(0)
+                    .generate_mode(generate_mode)
                     .build()
             ).collect::<Vec<_>>());
         let structname = &mockable.name;
         let traits = mockable.impls.into_iter()
-            .map(|i| MockTrait::new(structname, &generics, i, &vis))
+            .map(|i| MockTrait::new(structname, &generics, i, &vis, generate_mode))
             .collect();
 
         MockItemStruct {
@@ -235,7 +337,9 @@ impl From<MockableStruct> for MockItemStruct {
             modname,
             name: mockable.name,
             traits,
-            vis
+            vis,
+            generate_mode,
+            spy_real_type: mockable.spy_real_type,
         }
     }
 }
@@ -300,7 +404,20 @@ impl ToTokens for MockItemStruct {
                 quote!(#(#attrs)* #fieldname: #tyname #tg)
             }).collect::<Vec<_>>();
         field_definitions.extend(self.methods.field_definitions(modname));
-        field_definitions.extend(self.phantom_fields());
+        // In spy mode, add the __mockall_real field instead of phantom fields
+        if self.generate_mode == GenerateMode::Spy {
+            if let Some(ref real_ty) = self.spy_real_type {
+                field_definitions.push(
+                    quote!(__mockall_real: #real_ty)
+                );
+            } else {
+                field_definitions.push(
+                    quote!(__mockall_real: __MockallT)
+                );
+            }
+        } else {
+            field_definitions.extend(self.phantom_fields());
+        }
         let mut default_inits = substructs.iter()
             .filter(|ss| !ss.all_static())
             .map(|ss| {
@@ -312,7 +429,9 @@ impl ToTokens for MockItemStruct {
                 quote!(#(#attrs)* #fieldname: Default::default())
             }).collect::<Vec<_>>();
         default_inits.extend(self.methods.default_inits());
-        default_inits.extend(self.phantom_default_inits());
+        if self.generate_mode == GenerateMode::Mock {
+            default_inits.extend(self.phantom_default_inits());
+        }
         let trait_impls = self.traits.iter()
             .map(|trait_| {
                 let modname = format_ident!("{}_{}", &self.modname,
@@ -320,46 +439,100 @@ impl ToTokens for MockItemStruct {
                 trait_.trait_impl(&modname)
             }).collect::<Vec<_>>();
         let vis = &self.vis;
-        quote!(
-            #[allow(non_snake_case)]
-            #[allow(missing_docs)]
-            pub mod #modname {
-                use super::*;
-                #(#priv_mods)*
-            }
-            #[allow(non_camel_case_types)]
-            #[allow(non_snake_case)]
-            #[allow(missing_docs)]
-            #(#attrs)*
-            #vis struct #struct_name #ig #wc
-            {
-                #(#field_definitions),*
-            }
-            #debug_impl
-            impl #ig ::std::default::Default for #struct_name #tg #wc {
-                #[allow(clippy::default_trait_access)]
-                fn default() -> Self {
-                    Self {
-                        #(#default_inits),*
+
+        // Generate the struct definition and impl
+        if self.generate_mode == GenerateMode::Spy {
+            // Spy mode: no Default impl, custom new() that takes real value
+            let real_ty: TokenStream = if let Some(ref ty) = self.spy_real_type {
+                quote!(#ty)
+            } else {
+                quote!(__MockallT)
+            };
+            quote!(
+                #[allow(non_snake_case)]
+                #[allow(missing_docs)]
+                pub mod #modname {
+                    use super::*;
+                    #(#priv_mods)*
+                }
+                #[allow(non_camel_case_types)]
+                #[allow(non_snake_case)]
+                #[allow(missing_docs)]
+                #(#attrs)*
+                #vis struct #struct_name #ig #wc
+                {
+                    #(#field_definitions),*
+                }
+                #debug_impl
+                #(#substructs)*
+                impl #ig #struct_name #tg #wc {
+                    #(#consts)*
+                    #(#calls)*
+                    #(#contexts)*
+                    #(#expects)*
+                    /// Create a new spy wrapping the given real value.
+                    pub fn new(__mockall_real: #real_ty) -> Self {
+                        Self {
+                            __mockall_real,
+                            #(#default_inits),*
+                        }
+                    }
+                    /// Validate that all current expectations for all methods
+                    /// have been satisfied, and discard them.
+                    pub fn checkpoint(&mut self) {
+                        #(#substruct_expectations)*
+                        #(#method_checkpoints)*
                     }
                 }
-            }
-            #(#substructs)*
-            impl #ig #struct_name #tg #wc {
-                #(#consts)*
-                #(#calls)*
-                #(#contexts)*
-                #(#expects)*
-                /// Validate that all current expectations for all methods have
-                /// been satisfied, and discard them.
-                pub fn checkpoint(&mut self) {
-                    #(#substruct_expectations)*
-                    #(#method_checkpoints)*
+                #(#trait_impls)*
+                impl #ig ::mockall::SpyFrom<#real_ty> for #struct_name #tg #wc {
+                    fn spy_from(real: #real_ty) -> Self {
+                        #struct_name::new(real)
+                    }
                 }
-                #new_method
-            }
-            #(#trait_impls)*
-        ).to_tokens(tokens);
+            ).to_tokens(tokens);
+        } else {
+            quote!(
+                #[allow(non_snake_case)]
+                #[allow(missing_docs)]
+                pub mod #modname {
+                    use super::*;
+                    #(#priv_mods)*
+                }
+                #[allow(non_camel_case_types)]
+                #[allow(non_snake_case)]
+                #[allow(missing_docs)]
+                #(#attrs)*
+                #vis struct #struct_name #ig #wc
+                {
+                    #(#field_definitions),*
+                }
+                #debug_impl
+                impl #ig ::std::default::Default for #struct_name #tg #wc {
+                    #[allow(clippy::default_trait_access)]
+                    fn default() -> Self {
+                        Self {
+                            #(#default_inits),*
+                        }
+                    }
+                }
+                #(#substructs)*
+                impl #ig #struct_name #tg #wc {
+                    #(#consts)*
+                    #(#calls)*
+                    #(#contexts)*
+                    #(#expects)*
+                    /// Validate that all current expectations for all methods have
+                    /// been satisfied, and discard them.
+                    pub fn checkpoint(&mut self) {
+                        #(#substruct_expectations)*
+                        #(#method_checkpoints)*
+                    }
+                    #new_method
+                }
+                #(#trait_impls)*
+            ).to_tokens(tokens);
+        }
     }
 }
 

--- a/mockall_derive/src/mock_trait.rs
+++ b/mockall_derive/src/mock_trait.rs
@@ -13,6 +13,7 @@ use syn::{
 
 use crate::{
     AttrFormatter,
+    GenerateMode,
     mock_function::{self, MockFunction},
     compile_error
 };
@@ -57,10 +58,12 @@ impl MockTrait {
     /// * `struct_generics` - Generics of the parent structure
     /// * `impl_`  -    Mockable ItemImpl for a trait
     /// * `vis`     -   Visibility of the struct
+    /// * `generate_mode` - What kind of struct to generate
     pub fn new(structname: &Ident,
                struct_generics: &Generics,
                impl_: ItemImpl,
-               vis: &Visibility) -> Self
+               vis: &Visibility,
+               generate_mode: GenerateMode) -> Self
     {
         let mut consts = Vec::new();
         let mut methods = Vec::new();
@@ -95,6 +98,7 @@ impl MockTrait {
                         .struct_(structname)
                         .struct_generics(struct_generics)
                         .trait_(&ss_name)
+                        .generate_mode(generate_mode)
                         .build();
                     methods.push(mf);
                 },

--- a/mockall_derive/src/mockable_item.rs
+++ b/mockall_derive/src/mockable_item.rs
@@ -40,13 +40,10 @@ pub(crate) enum MockableItem {
 impl From<(Attrs, Item)> for MockableItem {
     fn from((attrs, item): (Attrs, Item)) -> MockableItem {
         match item {
-            Item::Impl(item_impl) =>
-                MockableItem::Struct(Box::new(MockableStruct::from(item_impl))),
-            Item::Mod(item_mod) =>
-                MockableItem::Module(MockableModule::from(item_mod)),
-            Item::Trait(trait_) =>
-                MockableItem::Struct(Box::new(MockableStruct::from((attrs, trait_)))),
-            _ => panic!("automock does not support this item type")
+            Item::Impl(item_impl) => MockableStruct::from(item_impl).into(),
+            Item::Mod(item_mod) => MockableItem::Module(MockableModule::from(item_mod)),
+            Item::Trait(trait_) => MockableStruct::from((attrs, trait_)).into(),
+            _ => panic!("automock does not support this item type"),
         }
     }
 }
@@ -60,15 +57,9 @@ impl From<MockableStruct> for MockableItem {
 impl MockableItem {
     pub fn from_autospy(attrs: Attrs, item: Item) -> MockableItem {
         match item {
-            Item::Impl(item_impl) =>
-                MockableItem::Struct(Box::new(
-                    MockableStruct::from_impl_spy(item_impl)
-                )),
-            Item::Trait(trait_) =>
-                MockableItem::Struct(Box::new(
-                    MockableStruct::from_trait_spy(attrs, trait_)
-                )),
-            _ => panic!("autospy only supports traits and struct impls")
+            Item::Impl(item_impl) => MockableStruct::from_impl_spy(item_impl).into(),
+            Item::Trait(trait_) => MockableStruct::from_trait_spy(attrs, trait_).into(),
+            _ => panic!("autospy only supports traits and struct impls"),
         }
     }
 }

--- a/mockall_derive/src/mockable_item.rs
+++ b/mockall_derive/src/mockable_item.rs
@@ -34,18 +34,18 @@ fn mockable_item(item: Item) -> Item {
 /// altered lifetimes.
 pub(crate) enum MockableItem {
     Module(MockableModule),
-    Struct(MockableStruct)
+    Struct(Box<MockableStruct>)
 }
 
 impl From<(Attrs, Item)> for MockableItem {
     fn from((attrs, item): (Attrs, Item)) -> MockableItem {
         match item {
             Item::Impl(item_impl) =>
-                MockableItem::Struct(MockableStruct::from(item_impl)),
+                MockableItem::Struct(Box::new(MockableStruct::from(item_impl))),
             Item::Mod(item_mod) =>
                 MockableItem::Module(MockableModule::from(item_mod)),
             Item::Trait(trait_) =>
-                MockableItem::Struct(MockableStruct::from((attrs, trait_))),
+                MockableItem::Struct(Box::new(MockableStruct::from((attrs, trait_)))),
             _ => panic!("automock does not support this item type")
         }
     }
@@ -53,7 +53,7 @@ impl From<(Attrs, Item)> for MockableItem {
 
 impl From<MockableStruct> for MockableItem {
     fn from(mock: MockableStruct) -> MockableItem {
-        MockableItem::Struct(mock)
+        MockableItem::Struct(Box::new(mock))
     }
 }
 
@@ -61,13 +61,13 @@ impl MockableItem {
     pub fn from_autospy(attrs: Attrs, item: Item) -> MockableItem {
         match item {
             Item::Impl(item_impl) =>
-                MockableItem::Struct(
+                MockableItem::Struct(Box::new(
                     MockableStruct::from_impl_spy(item_impl)
-                ),
+                )),
             Item::Trait(trait_) =>
-                MockableItem::Struct(
+                MockableItem::Struct(Box::new(
                     MockableStruct::from_trait_spy(attrs, trait_)
-                ),
+                )),
             _ => panic!("autospy only supports traits and struct impls")
         }
     }

--- a/mockall_derive/src/mockable_item.rs
+++ b/mockall_derive/src/mockable_item.rs
@@ -57,6 +57,22 @@ impl From<MockableStruct> for MockableItem {
     }
 }
 
+impl MockableItem {
+    pub fn from_autospy(attrs: Attrs, item: Item) -> MockableItem {
+        match item {
+            Item::Impl(item_impl) =>
+                MockableItem::Struct(
+                    MockableStruct::from_impl_spy(item_impl)
+                ),
+            Item::Trait(trait_) =>
+                MockableItem::Struct(
+                    MockableStruct::from_trait_spy(attrs, trait_)
+                ),
+            _ => panic!("autospy only supports traits and struct impls")
+        }
+    }
+}
+
 pub(crate) struct MockableModule {
     pub attrs: TokenStream,
     pub vis: Visibility,

--- a/mockall_derive/src/mockable_struct.rs
+++ b/mockall_derive/src/mockable_struct.rs
@@ -9,6 +9,7 @@ use syn::{
 
 use crate::{
     Attrs,
+    GenerateMode,
     compile_error,
     deanonymize,
     deimplify,
@@ -18,6 +19,7 @@ use crate::{
     dewhereselfify,
     find_ident_from_path,
     gen_mock_ident,
+    gen_spy_ident,
     AttrFormatter,
 };
 
@@ -123,7 +125,7 @@ fn derive_debug() -> Attribute {
 }
 
 /// Add "Mock" to the front of the named type
-fn mock_ident_in_type(ty: &mut Type) {
+fn set_ident_in_type(ty: &mut Type, target_name: &Ident) {
     match ty {
         Type::Path(type_path) => {
             if type_path.path.segments.len() != 1 {
@@ -132,7 +134,7 @@ fn mock_ident_in_type(ty: &mut Type) {
                 return;
             }
             let ident = &mut type_path.path.segments.last_mut().unwrap().ident;
-            *ident = gen_mock_ident(ident)
+            *ident = target_name.clone()
         },
         x => {
             compile_error(x.span(),
@@ -145,7 +147,7 @@ fn mock_ident_in_type(ty: &mut Type) {
 fn mockable_item_impl(mut impl_: ItemImpl, name: &Ident, generics: &Generics)
     -> ItemImpl
 {
-    mock_ident_in_type(&mut impl_.self_ty);
+    set_ident_in_type(&mut impl_.self_ty, name);
     for item in impl_.items.iter_mut() {
         if let ImplItem::Fn(ref mut iim) = item {
             mockable_method(iim, name, generics);
@@ -340,9 +342,192 @@ pub(crate) struct MockableStruct {
     pub name: Ident,
     pub vis: Visibility,
     pub impls: Vec<ItemImpl>,
+    /// What kind of struct to generate
+    pub generate_mode: GenerateMode,
+    /// For struct impl spy mode, the concrete type of the wrapped value.
+    /// `None` for trait-based spies and all mocks.
+    pub spy_real_type: Option<Type>,
 }
 
 impl MockableStruct {
+    /// Parse input for the `spy!` macro.
+    ///
+    /// Similar to the `Parse` impl for `mock!`, but:
+    /// - Uses `Spy` prefix instead of `Mock`
+    /// - Sets `generate_mode: GenerateMode::Spy`
+    /// - Rejects inherent methods (only consts allowed in the inherent block)
+    pub fn parse_spy(input: ParseStream) -> syn::parse::Result<Self> {
+        let attrs = input.call(syn::Attribute::parse_outer)?;
+        let vis: syn::Visibility = input.parse()?;
+        let original_name: syn::Ident = input.parse()?;
+        let mut generics: syn::Generics = input.parse()?;
+        let wc: Option<syn::WhereClause> = input.parse()?;
+        generics.where_clause = wc;
+        let name = gen_spy_ident(&original_name);
+        let impl_content;
+        let _brace_token = braced!(impl_content in input);
+        let mut consts = Vec::new();
+        while !impl_content.is_empty() {
+            let item: ImplItem = impl_content.parse()?;
+            match item {
+                ImplItem::Const(iic) => consts.push(iic),
+                ImplItem::Verbatim(_) | ImplItem::Fn(_) => {
+                    return Err(input.error(
+                        "spy! does not support inherent methods. \
+                         Only trait methods can be spied on."
+                    ));
+                }
+                _ => {
+                    return Err(input.error("Unsupported in this context"));
+                }
+            }
+        }
+
+        let mut impls = Vec::new();
+        while !input.is_empty() {
+            let item: Item = input.parse()?;
+            match item {
+                Item::Impl(mut ii) => {
+                    for item in ii.items.iter_mut() {
+                        if let ImplItem::Verbatim(ts) = item {
+                            let tif: TraitItemFn = parse2(ts.clone()).unwrap();
+                            let iim = tif2iif(tif, &Visibility::Inherited);
+                            *item = ImplItem::Fn(iim);
+                        }
+                    }
+                    impls.push(mockable_item_impl(ii, &name, &generics));
+                }
+                _ => return Err(input.error("Unsupported in this context")),
+            }
+        }
+
+        Ok(
+            MockableStruct {
+                attrs,
+                consts,
+                generics,
+                methods: Vec::new(),
+                name,
+                vis,
+                impls,
+                generate_mode: GenerateMode::Spy,
+                spy_real_type: None,
+            }
+        )
+    }
+
+    /// Create a MockableStruct in spy mode from an ItemTrait.
+    /// Used by `#[autospy]`.
+    pub fn from_trait_spy(attrs: Attrs, item_trait: ItemTrait) -> MockableStruct {
+        let trait_ = attrs.substitute_trait(&item_trait);
+        let mut attrs = AttrFormatter::new(&trait_.attrs)
+            .doc(true)
+            .async_trait(true)
+            .trait_variant(true)
+            .must_use(false)
+            .format();
+        attrs.push(derive_debug());
+        let vis = trait_.vis.clone();
+        let name = gen_spy_ident(&trait_.ident);
+        let generics = trait_.generics.clone();
+        let impls = vec![mockable_trait(trait_, &name, &generics)];
+        MockableStruct {
+            attrs,
+            consts: Vec::new(),
+            vis,
+            name,
+            generics,
+            methods: Vec::new(),
+            impls,
+            generate_mode: GenerateMode::Spy,
+            spy_real_type: None,
+        }
+    }
+
+    /// Create a MockableStruct in spy mode from an ItemImpl.
+    /// Used by `#[autospy]` on struct impl blocks.
+    pub fn from_impl_spy(mut item_impl: ItemImpl) -> MockableStruct {
+        let real_type = (*item_impl.self_ty).clone();
+        let name = match &*item_impl.self_ty {
+            Type::Path(type_path) => {
+                let n = find_ident_from_path(&type_path.path).0;
+                let self_generics =
+                    &type_path.path.segments.last().unwrap().arguments;
+                if let PathArguments::AngleBracketed(abga) = &self_generics {
+                    if item_impl.generics.params.len() != abga.args.len() {
+                        compile_error(item_impl.span(),
+                            "autospy does not currently support structs \
+                             with elided lifetimes");
+                    }
+                }
+                gen_spy_ident(&n)
+            },
+            x => {
+                compile_error(x.span(),
+                    "mockall_derive only supports mocking traits and structs");
+                Ident::new("", Span::call_site())
+            }
+        };
+        let mut attrs = item_impl.attrs.clone();
+        attrs.push(derive_debug());
+        let mut consts = Vec::new();
+        let generics = item_impl.generics.clone();
+        let mut methods = Vec::new();
+        let vis = Visibility::Public(Token![pub](Span::call_site()));
+        let mut impls = Vec::new();
+        let is_inherent = item_impl.trait_.is_none();
+        if let Some((bang, _path, _)) = &item_impl.trait_ {
+            if bang.is_some() {
+                compile_error(bang.span(), "Unsupported by autospy");
+            }
+
+            let mut attrs = Attrs::default();
+            for item in item_impl.items.iter() {
+                match item {
+                    ImplItem::Const(_iic) =>
+                        (),
+                    ImplItem::Fn(_meth) =>
+                        (),
+                    ImplItem::Type(ty) => {
+                        attrs.attrs.insert(ty.ident.clone(), ty.ty.clone());
+                    },
+                    x => compile_error(x.span(), "Unsupported by autospy")
+                }
+            }
+            attrs.substitute_item_impl(&mut item_impl);
+            impls.push(mockable_item_impl(item_impl, &name, &generics));
+        } else {
+            for item in item_impl.items.into_iter() {
+                match item {
+                    ImplItem::Fn(mut meth) => {
+                        mockable_method(
+                            &mut meth, &name, &item_impl.generics
+                        );
+                        methods.push(meth)
+                    },
+                    ImplItem::Const(iic) => consts.push(iic),
+                    x => compile_error(x.span(),
+                        "Unsupported by Mockall in this context"),
+                }
+            }
+        };
+        MockableStruct {
+            attrs,
+            consts,
+            generics,
+            methods,
+            name,
+            vis,
+            impls,
+            generate_mode: GenerateMode::Spy,
+            spy_real_type: if is_inherent {
+                Some(real_type)
+            } else {
+                None
+            },
+        }
+    }
+
     /// Does this struct derive Debug?
     pub fn derives_debug(&self) -> bool {
         self.attrs.iter()
@@ -386,7 +571,9 @@ impl From<(Attrs, ItemTrait)> for MockableStruct {
             name,
             generics,
             methods: Vec::new(),
-            impls
+            impls,
+            generate_mode: GenerateMode::Mock,
+            spy_real_type: None,
         }
     }
 }
@@ -467,6 +654,8 @@ impl From<ItemImpl> for MockableStruct {
             name,
             vis,
             impls,
+            generate_mode: GenerateMode::Mock,
+            spy_real_type: None,
         }
     }
 }
@@ -528,7 +717,9 @@ impl Parse for MockableStruct {
                 methods,
                 name,
                 vis,
-                impls
+                impls,
+                generate_mode: GenerateMode::Mock,
+                spy_real_type: None,
             }
         )
     }


### PR DESCRIPTION
Closes #567 

Adds
- `spy!` procedural macro (analogous to `mock!`)
- `#[autospy]` attribute macro (analogous to `#[automock]`)
- `real.into_spy()` helper which is a shorthand for `SpyFoo::new(real)`

Design decisions:
1. Spy reuses the existing mock pipeline: `MockItemStruct` / `MockFunction` / `MockTrait` with a `GenerateMode` flag. This keeps code duplication low but ties spy behavior to mock internals.
2. Trait spies are generic: `SpyFoo<T: MyTrait>` accepts any type that implements the trait. Struct spies use a concrete type directly because inherent methods have no trait to use as a bound.
4. `impl Trait` return-types (including plain `async fn`) are not supported. Because Mockall converts these to `Pin<Box<dyn Trait>>`, which causes a type mismatch when calling the real implementation.
    - `#[async_trait]` works because it does this conversion before mockall processes the trait. This is documented as a known limitation.
5. `calling_real()` is needed for verified delegation. Unlike Java (Mockito) / Ruby(RSpec) spy frameworks that record all calls and let you check them after the fact, Mockall requires expectations to be set up before the call. So, users must explicitly use `calling_real()` when they want to both delegate and verify.
