### PR TITLE
Fix unused_feature lints triggered by the latest nightly compiler

### DIFF
--- a/mockall/src/lib.rs
+++ b/mockall/src/lib.rs
@@ -1142,7 +1142,6 @@
 // incomplete; that's why it's guarded by the "nightly" feature.
 #![cfg_attr(feature = "nightly", allow(incomplete_features))]
 
-#![cfg_attr(feature = "nightly", feature(doc_cfg))]
 #![cfg_attr(test, deny(warnings))]
 #![warn(missing_docs)]
 

--- a/mockall_derive/src/lib.rs
+++ b/mockall_derive/src/lib.rs
@@ -5,7 +5,7 @@
 //! its reexports via the [`mockall`](https://docs.rs/mockall/latest/mockall)
 //! crate.
 
-#![cfg_attr(feature = "nightly_derive", feature(proc_macro_diagnostic))]
+#![cfg_attr(all(feature = "nightly_derive", not(test)), feature(proc_macro_diagnostic))]
 #![cfg_attr(test, deny(warnings))]
 // This lint is unhelpful.  See
 // https://github.com/rust-lang/rust-clippy/discussions/14256

--- a/mockall_double/src/lib.rs
+++ b/mockall_double/src/lib.rs
@@ -7,7 +7,7 @@
 //! However, it is defined in its own crate so that the bulk of Mockall can
 //! remain a dev-dependency, instead of a regular dependency.
 
-#![cfg_attr(feature = "nightly", feature(proc_macro_diagnostic))]
+#![cfg_attr(all(feature = "nightly", not(test)), feature(proc_macro_diagnostic))]
 #![cfg_attr(test, deny(warnings))]
 extern crate proc_macro;
 


### PR DESCRIPTION
The latest nightly compiler complains about unused_features three times:

* The doc_cfg feature in the mockall crate, which AFAICT hasn't actually been needed since September 2019.

* The proc_macro_diagnostic feature in the mockall_derive crate, which is only needed in non-test mode.

* The proc_macro_diagnostic feature in the mockall_double crate, which is only needed in non-test mode.