### PR TITLE
Add compatibility with the `#[auto_impl]` macro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [ Unreleased ] - ReleaseDate
+
+### Added
+
+- Compatibility with the `#[auto_impl]` macro.
+  ([#686](https://github.com/asomers/mockall/pull/686))
+
 ## [ 0.14.0 ] - 2025-11-22
 
 ### Added

--- a/mockall/Cargo.toml
+++ b/mockall/Cargo.toml
@@ -49,6 +49,7 @@ mockall_derive = { version = "=0.14.0", path = "../mockall_derive" }
 trait-variant = "0.1.2"
 async-trait = "0.1.38"
 auto_enums = "0.8.5"
+auto_impl = "1.3.0"
 futures = "0.3.7"
 mockall_double = { version = "^0.3.1", path = "../mockall_double" }
 serde = "1.0.113"

--- a/mockall/tests/automock_auto_impl.rs
+++ b/mockall/tests/automock_auto_impl.rs
@@ -1,0 +1,33 @@
+// vim: tw=80
+//! A trait that uses both `#[automock]` and `#[auto_impl]`.
+//!
+//! `#[auto_impl]` only applies to trait definitions, so `#[automock]` must not
+//! copy it onto the generated mock.
+#![deny(warnings)]
+
+use auto_impl::auto_impl;
+use mockall::*;
+
+#[automock]
+#[auto_impl(&, Box)]
+pub trait Foo {
+    fn foo(&self, x: u32) -> u32;
+}
+
+#[test]
+fn returning() {
+    let mut mock = MockFoo::new();
+    mock.expect_foo()
+        .returning(|x| x + 1);
+    assert_eq!(5, mock.foo(4));
+}
+
+// The mock is reachable through auto_impl's generated impl for Box.
+#[test]
+fn boxed() {
+    let mut mock = MockFoo::new();
+    mock.expect_foo()
+        .returning(|x| x + 1);
+    let boxed: Box<dyn Foo> = Box::new(mock);
+    assert_eq!(5, boxed.foo(4));
+}

--- a/mockall_derive/src/lib.rs
+++ b/mockall_derive/src/lib.rs
@@ -878,6 +878,10 @@ impl<'a> AttrFormatter<'a> {
                     // Ignore auto_enum, because we transform the return value
                     // into a trait object.
                     false
+                } else if *i.as_ref().unwrap() == "auto_impl" {
+                    // Ignore auto_impl, because it only applies to trait
+                    // definitions, not the generated mock struct or impl.
+                    false
                 } else {
                     true
                 }


### PR DESCRIPTION
`#[automock]` was copying the trait-only `#[auto_impl]` attribute onto the
generated mock, where it can't apply ("expected `trait`"). Strip it like
the other trait-only attributes so the two compose on one trait.
