### PR TITLE
Clippy cleanup

### DIFF
--- a/mockall/tests/automock_multiple_lifetime_parameters.rs
+++ b/mockall/tests/automock_multiple_lifetime_parameters.rs
@@ -6,6 +6,7 @@
 
 #![deny(warnings)]
 #![allow(clippy::needless_lifetimes)]
+#![allow(clippy::extra_unused_lifetimes)]
 
 use mockall::*;
 

--- a/mockall/tests/automock_where_self.rs
+++ b/mockall/tests/automock_where_self.rs
@@ -3,6 +3,7 @@
 //! not generic.
 #![deny(warnings)]
 #![allow(clippy::needless_lifetimes)]
+#![allow(clippy::extra_unused_lifetimes)]
 
 // Enclose the mocked trait within a non-public module.  With some versions of
 // rustc, that causes "unused method" errors for the generic code, but not the

--- a/mockall/tests/mock_life0.rs
+++ b/mockall/tests/mock_life0.rs
@@ -3,6 +3,7 @@
 //! https://github.com/asomers/mockall/issues/95
 #![deny(warnings)]
 #![allow(single_use_lifetimes)] // The lifetime is the whole point of this test
+#![allow(clippy::extra_unused_lifetimes)]
 
 use mockall::*;
 

--- a/mockall_derive/src/lib.rs
+++ b/mockall_derive/src/lib.rs
@@ -1425,7 +1425,6 @@ fn assert_not_contains(output: &str, tokens: TokenStream) {
 /// write as integration tests
 mod mock {
     use std::str::FromStr;
-    use super::super::*;
     use super::*;
 
     #[test]
@@ -1502,7 +1501,6 @@ mod mock {
 /// write as integration tests
 mod automock {
     use std::str::FromStr;
-    use super::super::*;
     use super::*;
 
     #[test]


### PR DESCRIPTION
* Some unit tests trigger unused_imports warnings with the latest rustc. Fix it.
* Several integration tests trigger clippy::extra_unused_lifetimes warnings with the latest Rustc.  The lifetimes really are unused, but are important to the test logic.  Suppress them.